### PR TITLE
Add auto game detection with Steam AppID/process fallback and automatic profile switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This project listens to the game’s telemetry/UDP data output and drives the wh
 - Simple UI: select game → Start
 - Works with multiple telemetry formats (see supported games below)
 - Auto-reconnect telemetry loop (recovers after game/launcher transitions)
+- Optional auto-detect mode: switches selected game profile from running Steam game/process
 - Assetto Corsa max RPM is persisted in `~/.config/logitech-rpm-indicator/settings.ini`
 
 ---
@@ -91,8 +92,9 @@ python main.py
 2. Start the application:
    - From package install: `logitech-rpm-indicator`
    - From source: `python main.py`
-3. Select the game from the dropdown and click **Start**.
-4. Launch the game and ensure telemetry output is enabled (instructions below).
+3. Optional: enable **Auto-detect running game (Steam/process)** to auto-switch profiles.
+4. Select the game from the dropdown and click **Start**.
+5. Launch the game and ensure telemetry output is enabled (instructions below).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ This project listens to the game’s telemetry/UDP data output and drives the wh
 - Works with multiple telemetry formats (see supported games below)
 - Auto-reconnect telemetry loop (recovers after game/launcher transitions)
 - Optional auto-detect mode: switches selected game profile from running Steam game/process
+- In auto-detect mode, telemetry stops automatically when no supported game is running
 - Assetto Corsa max RPM is persisted in `~/.config/logitech-rpm-indicator/settings.ini`
+- Optional "Remember last selected game" restores the dropdown selection on app launch
 
 ---
 
@@ -93,8 +95,9 @@ python main.py
    - From package install: `logitech-rpm-indicator`
    - From source: `python main.py`
 3. Optional: enable **Auto-detect running game (Steam/process)** to auto-switch profiles.
-4. Select the game from the dropdown and click **Start**.
-5. Launch the game and ensure telemetry output is enabled (instructions below).
+4. Optional: enable **Remember last selected game** to restore the dropdown on startup.
+5. Select the game from the dropdown and click **Start**.
+6. Launch the game and ensure telemetry output is enabled (instructions below).
 
 ---
 

--- a/games/autodetect.py
+++ b/games/autodetect.py
@@ -1,0 +1,129 @@
+import os
+from pathlib import Path
+
+STEAM_APP_ID_KEYS = (
+    b"SteamAppId=",
+    b"STEAM_COMPAT_APP_ID=",
+    b"SteamGameId=",
+)
+
+GAME_SIGNATURES = (
+    {
+        "key": "forza_horizon_5",
+        "steam_app_ids": {"1551360"},
+        "process_tokens": ("forzahorizon5.exe", "forza horizon 5"),
+    },
+    {
+        "key": "f1_2019",
+        "steam_app_ids": {"928600"},
+        "process_tokens": ("f1_2019.exe",),
+    },
+    {
+        "key": "f1_2020",
+        "steam_app_ids": {"1080110"},
+        "process_tokens": ("f1_2020.exe",),
+    },
+    {
+        "key": "f1_2022",
+        "steam_app_ids": {"1692250"},
+        "process_tokens": ("f1_22.exe", "f1_2022.exe"),
+    },
+    {
+        "key": "f1_2023",
+        "steam_app_ids": {"2108330"},
+        "process_tokens": ("f1_23.exe", "f1_2023.exe"),
+    },
+    {
+        "key": "dirt_rally_2_0",
+        "steam_app_ids": {"690790"},
+        "process_tokens": ("dirtrally2.exe", "dirt rally 2.0"),
+    },
+    {
+        "key": "ams_2",
+        "steam_app_ids": {"1066890", "234630", "378860"},
+        "process_tokens": (
+            "ams2avx.exe",
+            "ams2.exe",
+            "pcars64.exe",
+            "pcars2avx.exe",
+            "project cars",
+            "project cars 2",
+        ),
+    },
+    {
+        "key": "assetto_corsa",
+        "steam_app_ids": {"244210"},
+        "process_tokens": ("assettocorsa.exe", "assetto corsa"),
+    },
+)
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="ignore").strip().lower()
+    except OSError:
+        return ""
+
+
+def _read_cmdline(path: Path) -> str:
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        return ""
+    parts = [part.decode("utf-8", errors="ignore") for part in raw.split(b"\0") if part]
+    return " ".join(parts).lower()
+
+
+def _read_steam_app_id(path: Path) -> str:
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        return ""
+    for entry in raw.split(b"\0"):
+        for key in STEAM_APP_ID_KEYS:
+            if entry.startswith(key):
+                return entry[len(key):].decode("ascii", errors="ignore")
+    return ""
+
+
+def detect_game_from_processes(processes):
+    for process in processes:
+        app_id = process.get("steam_app_id", "")
+        if not app_id:
+            continue
+        for signature in GAME_SIGNATURES:
+            if app_id in signature["steam_app_ids"]:
+                return signature["key"]
+
+    for process in processes:
+        name = process.get("name", "").lower()
+        cmdline = process.get("cmdline", "").lower()
+        haystack = f"{name} {cmdline}"
+        for signature in GAME_SIGNATURES:
+            for token in signature["process_tokens"]:
+                if token in haystack:
+                    return signature["key"]
+    return None
+
+
+def detect_running_game():
+    proc_dir = Path("/proc")
+    processes = []
+    try:
+        entries = os.scandir(proc_dir)
+    except OSError:
+        return None
+
+    with entries as proc_entries:
+        for entry in proc_entries:
+            if not entry.name.isdigit():
+                continue
+            pid_path = proc_dir / entry.name
+            processes.append(
+                {
+                    "name": _read_text(pid_path / "comm"),
+                    "cmdline": _read_cmdline(pid_path / "cmdline"),
+                    "steam_app_id": _read_steam_app_id(pid_path / "environ"),
+                }
+            )
+    return detect_game_from_processes(processes)

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ from games.f12023 import F12023
 from games.dirt_rally_2_0 import DirtRally2
 from games.automobilista_2 import Automobilista2
 from games.assetto_corsa import AssettoCorsa
+from games.autodetect import detect_running_game
 from wheels.detect import find_wheel
 
 FORZA_HORIZON_5 =   0
@@ -35,6 +36,18 @@ MIN_ASSETTO_MAX_RPM = 1000
 MAX_ASSETTO_MAX_RPM = 20000
 RECONNECT_DELAY_SECONDS = 1.0
 RECONNECT_INACTIVITY_SECONDS = 3.0
+AUTO_DETECT_INTERVAL_SECONDS = 1.0
+
+GAME_KEY_TO_CHOICE = {
+    "forza_horizon_5": FORZA_HORIZON_5,
+    "f1_2019": F1_2019,
+    "f1_2020": F1_2020,
+    "f1_2022": F1_2022,
+    "f1_2023": F1_2023,
+    "dirt_rally_2_0": DIRT_RALLY_2_0,
+    "ams_2": AMS_2,
+    "assetto_corsa": ASSETTO_CORSA,
+}
 
 APP_CSS = """
 .rpm-window {
@@ -127,6 +140,9 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
         self.stop_event = threading.Event()
         self.running = False
         self.shared_rpm_percent = 0
+        self.active_game_choice = None
+        self.auto_detect_enabled = False
+        self.last_auto_detect_check = 0.0
         self.settings_path = self._get_settings_path()
         self.assetto_max_rpm = DEFAULT_ASSETTO_MAX_RPM
         self._load_settings()
@@ -185,6 +201,11 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
         self.combo.set_enable_search(True)
         game_panel.append(self.combo)
         self.combo.connect("notify::selected", self._on_game_selected_changed)
+
+        self.auto_detect_checkbox = Gtk.CheckButton(label="Auto-detect running game (Steam/process)")
+        self.auto_detect_checkbox.set_active(self.auto_detect_enabled)
+        self.auto_detect_checkbox.connect("toggled", self._on_auto_detect_toggled)
+        game_panel.append(self.auto_detect_checkbox)
 
         self.assetto_max_rpm_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
         self.assetto_max_rpm_label = Gtk.Label(label="Assetto Max RPM")
@@ -296,6 +317,9 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
             return
         try:
             parser.read(self.settings_path, encoding="utf-8")
+            self.auto_detect_enabled = parser.getboolean(
+                "general", "auto_detect", fallback=False
+            )
             value = parser.getint(
                 "assetto_corsa", "max_rpm", fallback=DEFAULT_ASSETTO_MAX_RPM
             )
@@ -305,6 +329,7 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
 
     def _save_settings(self):
         parser = configparser.ConfigParser()
+        parser["general"] = {"auto_detect": str(self.auto_detect_enabled).lower()}
         parser["assetto_corsa"] = {"max_rpm": str(int(self.assetto_max_rpm))}
         try:
             self.settings_path.parent.mkdir(parents=True, exist_ok=True)
@@ -315,6 +340,11 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
 
     def _on_assetto_max_rpm_changed(self, _spin):
         self.assetto_max_rpm = int(self.assetto_max_rpm_input.get_value())
+        self._save_settings()
+
+    def _on_auto_detect_toggled(self, _checkbox):
+        self.auto_detect_enabled = self.auto_detect_checkbox.get_active()
+        self.last_auto_detect_check = 0.0
         self._save_settings()
 
     def _update_wheel_status(self):
@@ -369,8 +399,10 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
         if self.running and (self.thread is None or not self.thread.is_alive()):
             self.running = False
             self.thread = None
+            self.active_game_choice = None
             self._update_running_status()
             self.shared_rpm_percent = 0
+        self._run_auto_detect_cycle()
         display_percent = self.shared_rpm_percent if self.running else 0
         self._update_rpm_preview(display_percent)
         return True
@@ -384,6 +416,7 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
         self.shared_rpm_percent = 0
         self._update_rpm_preview(0)
         self.thread = None
+        self.active_game_choice = None
         self.running = False
 
     def _on_close_request(self, _window):
@@ -404,51 +437,83 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
         )
         WheelRPMWindow._css_loaded = True
 
+    def _create_game_from_choice(self, choice):
+        if choice == FORZA_HORIZON_5:
+            return ForzaHorizon5()
+        if choice == F1_2019:
+            return F12019()
+        if choice == F1_2020:
+            return F12020()
+        if choice == F1_2022:
+            return F12022()
+        if choice == F1_2023:
+            return F12023()
+        if choice == DIRT_RALLY_2_0:
+            return DirtRally2()
+        if choice == AMS_2:
+            return Automobilista2()
+        if choice == ASSETTO_CORSA:
+            self.assetto_max_rpm = int(self.assetto_max_rpm_input.get_value())
+            self._save_settings()
+            return AssettoCorsa(max_rpm=self.assetto_max_rpm)
+        return None
+
+    def _start_telemetry_for_choice(self, choice):
+        game = self._create_game_from_choice(choice)
+        if game is None:
+            print("No game selected.")
+            return False
+
+        self.running = True
+        self.stop_event.clear()
+        self.shared_rpm_percent = 0
+        self.active_game_choice = choice
+        self.thread = threading.Thread(
+            target=self.game_handling_loop,
+            args=(game, self.wheel, choice),
+            daemon=True,
+        )
+        self.thread.start()
+        self._update_running_status()
+        return True
+
+    def _run_auto_detect_cycle(self):
+        if not self.auto_detect_enabled:
+            return
+
+        now = time.monotonic()
+        if now - self.last_auto_detect_check < AUTO_DETECT_INTERVAL_SECONDS:
+            return
+        self.last_auto_detect_check = now
+
+        detected_game_key = detect_running_game()
+        detected_choice = GAME_KEY_TO_CHOICE.get(detected_game_key)
+        if detected_choice is None:
+            return
+
+        if self.combo.get_selected() != detected_choice:
+            self.combo.set_selected(detected_choice)
+
+        if not self.running:
+            self._start_telemetry_for_choice(detected_choice)
+            return
+
+        if self.active_game_choice != detected_choice:
+            self._stop_telemetry()
+            self._update_running_status()
+            self._start_telemetry_for_choice(detected_choice)
+
     def on_button_clicked(self, _button):
         if self.running and (self.thread is None or not self.thread.is_alive()):
             self.running = False
             self.thread = None
+            self.active_game_choice = None
             self._update_running_status()
             self.shared_rpm_percent = 0
             self._update_rpm_preview(0)
 
-        choice = self.combo.get_selected()
-        if choice == FORZA_HORIZON_5:
-            game = ForzaHorizon5()
-        elif choice == F1_2019:
-            game = F12019()
-        elif choice == F1_2020:
-            game = F12020()
-        elif choice == F1_2022:
-            game = F12022()
-        elif choice == F1_2023:
-            game = F12023()
-        elif choice == DIRT_RALLY_2_0:
-            game = DirtRally2()
-        elif choice == AMS_2:
-            game = Automobilista2()
-        elif choice == ASSETTO_CORSA:
-            self.assetto_max_rpm = int(self.assetto_max_rpm_input.get_value())
-            self._save_settings()
-            game = AssettoCorsa(max_rpm=self.assetto_max_rpm)
-        else:
-            game = None
-
-        if game is None:
-            print("No game selected.")
-            return
-
         if not self.running:
-            self.running = True
-            self.stop_event.clear()
-            self.shared_rpm_percent = 0
-            self.thread = threading.Thread(
-                target=self.game_handling_loop,
-                args=(game, self.wheel, choice),
-                daemon=True,
-            )
-            self.thread.start()
-            self._update_running_status()
+            self._start_telemetry_for_choice(self.combo.get_selected())
         else:
             self._stop_telemetry()
             self._update_running_status()

--- a/main.py
+++ b/main.py
@@ -37,6 +37,8 @@ MAX_ASSETTO_MAX_RPM = 20000
 RECONNECT_DELAY_SECONDS = 1.0
 RECONNECT_INACTIVITY_SECONDS = 3.0
 AUTO_DETECT_INTERVAL_SECONDS = 1.0
+DEFAULT_REMEMBER_LAST_GAME = False
+DEFAULT_LAST_SELECTED_GAME = FORZA_HORIZON_5
 
 GAME_KEY_TO_CHOICE = {
     "forza_horizon_5": FORZA_HORIZON_5,
@@ -142,6 +144,8 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
         self.shared_rpm_percent = 0
         self.active_game_choice = None
         self.auto_detect_enabled = False
+        self.remember_last_selected_game = DEFAULT_REMEMBER_LAST_GAME
+        self.last_selected_game_choice = DEFAULT_LAST_SELECTED_GAME
         self.last_auto_detect_check = 0.0
         self.settings_path = self._get_settings_path()
         self.assetto_max_rpm = DEFAULT_ASSETTO_MAX_RPM
@@ -206,6 +210,14 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
         self.auto_detect_checkbox.set_active(self.auto_detect_enabled)
         self.auto_detect_checkbox.connect("toggled", self._on_auto_detect_toggled)
         game_panel.append(self.auto_detect_checkbox)
+
+        self.remember_last_game_checkbox = Gtk.CheckButton(label="Remember last selected game")
+        self.remember_last_game_checkbox.set_active(self.remember_last_selected_game)
+        self.remember_last_game_checkbox.connect("toggled", self._on_remember_last_game_toggled)
+        game_panel.append(self.remember_last_game_checkbox)
+
+        if self.remember_last_selected_game and self._is_valid_choice(self.last_selected_game_choice):
+            self.combo.set_selected(self.last_selected_game_choice)
 
         self.assetto_max_rpm_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
         self.assetto_max_rpm_label = Gtk.Label(label="Assetto Max RPM")
@@ -302,6 +314,11 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
         value_box.append(label)
         row.append(value_box)
 
+    def _is_valid_choice(self, choice):
+        if choice == Gtk.INVALID_LIST_POSITION:
+            return False
+        return 0 <= int(choice) < self.model_widget.get_n_items()
+
     @staticmethod
     def _get_settings_path():
         config_home = os.environ.get("XDG_CONFIG_HOME")
@@ -320,6 +337,12 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
             self.auto_detect_enabled = parser.getboolean(
                 "general", "auto_detect", fallback=False
             )
+            self.remember_last_selected_game = parser.getboolean(
+                "general", "remember_last_game", fallback=DEFAULT_REMEMBER_LAST_GAME
+            )
+            self.last_selected_game_choice = parser.getint(
+                "general", "last_selected_game", fallback=DEFAULT_LAST_SELECTED_GAME
+            )
             value = parser.getint(
                 "assetto_corsa", "max_rpm", fallback=DEFAULT_ASSETTO_MAX_RPM
             )
@@ -329,7 +352,11 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
 
     def _save_settings(self):
         parser = configparser.ConfigParser()
-        parser["general"] = {"auto_detect": str(self.auto_detect_enabled).lower()}
+        parser["general"] = {
+            "auto_detect": str(self.auto_detect_enabled).lower(),
+            "remember_last_game": str(self.remember_last_selected_game).lower(),
+            "last_selected_game": str(int(self.last_selected_game_choice)),
+        }
         parser["assetto_corsa"] = {"max_rpm": str(int(self.assetto_max_rpm))}
         try:
             self.settings_path.parent.mkdir(parents=True, exist_ok=True)
@@ -347,6 +374,12 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
         self.last_auto_detect_check = 0.0
         self._save_settings()
 
+    def _on_remember_last_game_toggled(self, _checkbox):
+        self.remember_last_selected_game = self.remember_last_game_checkbox.get_active()
+        if self._is_valid_choice(self.combo.get_selected()):
+            self.last_selected_game_choice = int(self.combo.get_selected())
+        self._save_settings()
+
     def _update_wheel_status(self):
         if self.wheel:
             self.wheel_status_icon.set_from_icon_name("emblem-ok-symbolic")
@@ -356,7 +389,12 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
         self.wheel_status_text.set_text("Not detected (preview only)")
 
     def _on_game_selected_changed(self, *_args):
-        self.assetto_max_rpm_row.set_visible(self.combo.get_selected() == ASSETTO_CORSA)
+        selected_choice = self.combo.get_selected()
+        self.assetto_max_rpm_row.set_visible(selected_choice == ASSETTO_CORSA)
+        if self._is_valid_choice(selected_choice):
+            self.last_selected_game_choice = int(selected_choice)
+            if self.remember_last_selected_game:
+                self._save_settings()
 
     @staticmethod
     def _percent_to_led_bits(percent):
@@ -489,6 +527,9 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
         detected_game_key = detect_running_game()
         detected_choice = GAME_KEY_TO_CHOICE.get(detected_game_key)
         if detected_choice is None:
+            if self.running and self.active_game_choice is not None:
+                self._stop_telemetry()
+                self._update_running_status()
             return
 
         if self.combo.get_selected() != detected_choice:

--- a/main.py
+++ b/main.py
@@ -153,7 +153,7 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
 
         self._ensure_css()
         self.add_css_class("rpm-window")
-        self.set_title("G29 RPM LED indicator")
+        self.set_title("Logitech RPM LED indicator")
         self.set_default_size(560, 350)
         self.set_size_request(460, 300)
 

--- a/tests/test_game_autodetect.py
+++ b/tests/test_game_autodetect.py
@@ -1,0 +1,33 @@
+import unittest
+
+from games.autodetect import detect_game_from_processes
+
+
+class TestGameAutoDetect(unittest.TestCase):
+    def test_detects_by_steam_app_id(self) -> None:
+        processes = [
+            {"name": "wine64", "cmdline": "wine64-preloader", "steam_app_id": ""},
+            {"name": "wineserver", "cmdline": "", "steam_app_id": "244210"},
+        ]
+        self.assertEqual(detect_game_from_processes(processes), "assetto_corsa")
+
+    def test_detects_by_process_token(self) -> None:
+        processes = [
+            {
+                "name": "wine64-preloader",
+                "cmdline": "/path/to/F1_23.exe",
+                "steam_app_id": "",
+            }
+        ]
+        self.assertEqual(detect_game_from_processes(processes), "f1_2023")
+
+    def test_returns_none_when_no_match(self) -> None:
+        processes = [
+            {"name": "steam", "cmdline": "steamwebhelper", "steam_app_id": ""},
+            {"name": "python", "cmdline": "main.py", "steam_app_id": ""},
+        ]
+        self.assertIsNone(detect_game_from_processes(processes))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Added optional **Auto-detect running game (Steam/process)** mode in the UI.
- Implemented game detection using:
  - **Steam AppID** from `/proc/*/environ` (preferred)
  - **Process name/cmdline token matching** as fallback
- Auto-detect now:
  - Switches dropdown profile automatically
  - Starts telemetry automatically when idle
  - Stops/restarts telemetry when detected game changes
- Persisted auto-detect setting in `settings.ini` (alongside existing Assetto max RPM setting).
- Added tests for detector logic:
  - Steam AppID detection
  - Process-token detection
  - No-match behavior
- Updated README with feature and usage notes.

## Validation

- `python -m py_compile main.py games/autodetect.py games/assetto_corsa.py tests/test_telemetry_parsers.py tests/test_game_autodetect.py`
- `python -m unittest -v tests/test_telemetry_parsers.py tests/test_game_autodetect.py`
- Result: **All tests passed**.
