### PR TITLE
Improve RPM range display

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This project listens to the game’s telemetry/UDP data output and drives the wh
 - In auto-detect mode, telemetry stops automatically when no supported game is running
 - Assetto Corsa max RPM is persisted in `~/.config/logitech-rpm-indicator/settings.ini`
 - Optional "Remember last selected game" restores the dropdown selection on app launch
+- Shift-light RPM thresholds are user-configurable in UI and persisted in settings
 
 ---
 
@@ -96,8 +97,9 @@ python main.py
    - From source: `python main.py`
 3. Optional: enable **Auto-detect running game (Steam/process)** to auto-switch profiles.
 4. Optional: enable **Remember last selected game** to restore the dropdown on startup.
-5. Select the game from the dropdown and click **Start**.
-6. Launch the game and ensure telemetry output is enabled (instructions below).
+5. Optional: tune **Shift LEDs (%)** thresholds to match your preferred shift-light band.
+6. Select the game from the dropdown and click **Start**.
+7. Launch the game and ensure telemetry output is enabled (instructions below).
 
 ---
 

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ from games.dirt_rally_2_0 import DirtRally2
 from games.automobilista_2 import Automobilista2
 from games.assetto_corsa import AssettoCorsa
 from games.autodetect import detect_running_game
+from wheels.base import BaseWheel
 from wheels.detect import find_wheel
 
 FORZA_HORIZON_5 =   0
@@ -39,6 +40,7 @@ RECONNECT_INACTIVITY_SECONDS = 3.0
 AUTO_DETECT_INTERVAL_SECONDS = 1.0
 DEFAULT_REMEMBER_LAST_GAME = False
 DEFAULT_LAST_SELECTED_GAME = FORZA_HORIZON_5
+SHIFT_LIGHT_THRESHOLD_COUNT = 5
 
 GAME_KEY_TO_CHOICE = {
     "forza_horizon_5": FORZA_HORIZON_5,
@@ -149,7 +151,10 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
         self.last_auto_detect_check = 0.0
         self.settings_path = self._get_settings_path()
         self.assetto_max_rpm = DEFAULT_ASSETTO_MAX_RPM
+        self.shift_light_thresholds = tuple(BaseWheel.DEFAULT_SHIFT_LIGHT_THRESHOLDS)
+        self._updating_shift_light_inputs = False
         self._load_settings()
+        self.shift_light_thresholds = BaseWheel.set_shift_light_thresholds(self.shift_light_thresholds)
 
         self._ensure_css()
         self.add_css_class("rpm-window")
@@ -218,6 +223,23 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
 
         if self.remember_last_selected_game and self._is_valid_choice(self.last_selected_game_choice):
             self.combo.set_selected(self.last_selected_game_choice)
+
+        self.shift_light_threshold_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        self.shift_light_threshold_label = Gtk.Label(label="Shift LEDs (%)")
+        self.shift_light_threshold_label.set_xalign(0)
+        self.shift_light_threshold_label.set_hexpand(True)
+        self.shift_light_threshold_row.append(self.shift_light_threshold_label)
+        self.shift_light_threshold_inputs = []
+        for index, threshold in enumerate(self.shift_light_thresholds):
+            threshold_input = Gtk.SpinButton.new_with_range(0, 100, 1)
+            threshold_input.set_numeric(True)
+            threshold_input.set_width_chars(3)
+            threshold_input.set_value(threshold)
+            threshold_input.set_tooltip_text(f"LED {index + 1} threshold")
+            threshold_input.connect("value-changed", self._on_shift_light_threshold_changed, index)
+            self.shift_light_threshold_inputs.append(threshold_input)
+            self.shift_light_threshold_row.append(threshold_input)
+        game_panel.append(self.shift_light_threshold_row)
 
         self.assetto_max_rpm_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
         self.assetto_max_rpm_label = Gtk.Label(label="Assetto Max RPM")
@@ -328,6 +350,20 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
             base_dir = Path.home() / ".config"
         return base_dir / "logitech-rpm-indicator" / "settings.ini"
 
+    @staticmethod
+    def _serialize_shift_light_thresholds(thresholds):
+        return ",".join(str(int(threshold)) for threshold in thresholds)
+
+    @staticmethod
+    def _parse_shift_light_thresholds(raw_value):
+        try:
+            parsed = [int(part.strip()) for part in raw_value.split(",") if part.strip() != ""]
+        except ValueError:
+            return tuple(BaseWheel.DEFAULT_SHIFT_LIGHT_THRESHOLDS)
+        if len(parsed) != SHIFT_LIGHT_THRESHOLD_COUNT:
+            return tuple(BaseWheel.DEFAULT_SHIFT_LIGHT_THRESHOLDS)
+        return tuple(parsed)
+
     def _load_settings(self):
         parser = configparser.ConfigParser()
         if not self.settings_path.exists():
@@ -347,6 +383,12 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
                 "assetto_corsa", "max_rpm", fallback=DEFAULT_ASSETTO_MAX_RPM
             )
             self.assetto_max_rpm = max(MIN_ASSETTO_MAX_RPM, min(value, MAX_ASSETTO_MAX_RPM))
+            shift_thresholds_raw = parser.get(
+                "shift_lights",
+                "thresholds",
+                fallback=self._serialize_shift_light_thresholds(BaseWheel.DEFAULT_SHIFT_LIGHT_THRESHOLDS),
+            )
+            self.shift_light_thresholds = self._parse_shift_light_thresholds(shift_thresholds_raw)
         except Exception as exc:
             print(f"Failed to read settings: {exc}")
 
@@ -358,12 +400,34 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
             "last_selected_game": str(int(self.last_selected_game_choice)),
         }
         parser["assetto_corsa"] = {"max_rpm": str(int(self.assetto_max_rpm))}
+        parser["shift_lights"] = {
+            "thresholds": self._serialize_shift_light_thresholds(self.shift_light_thresholds)
+        }
         try:
             self.settings_path.parent.mkdir(parents=True, exist_ok=True)
             with self.settings_path.open("w", encoding="utf-8") as settings_file:
                 parser.write(settings_file)
         except Exception as exc:
             print(f"Failed to write settings: {exc}")
+
+    def _set_shift_light_thresholds(self, thresholds, save=True):
+        self.shift_light_thresholds = BaseWheel.set_shift_light_thresholds(thresholds)
+        self._sync_shift_light_threshold_inputs()
+        display_percent = self.shared_rpm_percent if self.running else 0
+        self._update_rpm_preview(display_percent)
+        if save:
+            self._save_settings()
+
+    def _sync_shift_light_threshold_inputs(self):
+        if not hasattr(self, "shift_light_threshold_inputs"):
+            return
+        self._updating_shift_light_inputs = True
+        try:
+            for threshold_input, threshold in zip(self.shift_light_threshold_inputs, self.shift_light_thresholds):
+                if int(threshold_input.get_value()) != int(threshold):
+                    threshold_input.set_value(int(threshold))
+        finally:
+            self._updating_shift_light_inputs = False
 
     def _on_assetto_max_rpm_changed(self, _spin):
         self.assetto_max_rpm = int(self.assetto_max_rpm_input.get_value())
@@ -379,6 +443,12 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
         if self._is_valid_choice(self.combo.get_selected()):
             self.last_selected_game_choice = int(self.combo.get_selected())
         self._save_settings()
+
+    def _on_shift_light_threshold_changed(self, _spin, _index):
+        if self._updating_shift_light_inputs:
+            return
+        thresholds = [int(input_widget.get_value()) for input_widget in self.shift_light_threshold_inputs]
+        self._set_shift_light_thresholds(thresholds, save=True)
 
     def _update_wheel_status(self):
         if self.wheel:
@@ -398,14 +468,7 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
 
     @staticmethod
     def _percent_to_led_bits(percent):
-        return (
-            0b11111 if percent > 84
-            else 0b01111 if percent > 69
-            else 0b00111 if percent > 39
-            else 0b00011 if percent > 19
-            else 0b00001 if percent > 4
-            else 0
-        )
+        return BaseWheel._percent_to_bits(percent)
 
     def _update_rpm_preview(self, percent):
         clamped = max(0, min(int(percent), 100))

--- a/tests/test_shift_light_mapping.py
+++ b/tests/test_shift_light_mapping.py
@@ -1,0 +1,37 @@
+import unittest
+
+from wheels.base import BaseWheel
+
+
+class TestShiftLightMapping(unittest.TestCase):
+    def tearDown(self) -> None:
+        BaseWheel.set_shift_light_thresholds(BaseWheel.DEFAULT_SHIFT_LIGHT_THRESHOLDS)
+
+    def test_leds_stay_off_below_shift_band(self) -> None:
+        BaseWheel.set_shift_light_thresholds(BaseWheel.DEFAULT_SHIFT_LIGHT_THRESHOLDS)
+        self.assertEqual(BaseWheel._percent_to_bits(67), 0)
+
+    def test_threshold_boundaries(self) -> None:
+        BaseWheel.set_shift_light_thresholds(BaseWheel.DEFAULT_SHIFT_LIGHT_THRESHOLDS)
+        self.assertEqual(BaseWheel._percent_to_bits(68), 0b00001)
+        self.assertEqual(BaseWheel._percent_to_bits(76), 0b00011)
+        self.assertEqual(BaseWheel._percent_to_bits(84), 0b00111)
+        self.assertEqual(BaseWheel._percent_to_bits(91), 0b01111)
+        self.assertEqual(BaseWheel._percent_to_bits(96), 0b11111)
+
+    def test_custom_thresholds_change_activation_points(self) -> None:
+        BaseWheel.set_shift_light_thresholds((80, 85, 90, 95, 99))
+        self.assertEqual(BaseWheel._percent_to_bits(79), 0)
+        self.assertEqual(BaseWheel._percent_to_bits(85), 0b00011)
+
+    def test_unsorted_thresholds_are_normalized(self) -> None:
+        normalized = BaseWheel.set_shift_light_thresholds((90, 10, 10, 10, 10))
+        self.assertEqual(normalized, (90, 91, 92, 93, 94))
+
+    def test_invalid_threshold_count_resets_defaults(self) -> None:
+        normalized = BaseWheel.set_shift_light_thresholds((80, 90, 95))
+        self.assertEqual(normalized, tuple(BaseWheel.DEFAULT_SHIFT_LIGHT_THRESHOLDS))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wheels/base.py
+++ b/wheels/base.py
@@ -13,6 +13,8 @@ _led_report(bits: int) -> Sequence[int]
     """
     VENDOR_ID: int = 0x046d          # Logitech
     PRODUCT_IDS: Iterable[int] = ()
+    DEFAULT_SHIFT_LIGHT_THRESHOLDS: Sequence[int] = (68, 76, 84, 91, 96)
+    SHIFT_LIGHT_THRESHOLDS: Sequence[int] = DEFAULT_SHIFT_LIGHT_THRESHOLDS
 
     def __init__(self) -> None:
         self._dev: hid.Device | None = None
@@ -44,13 +46,27 @@ _led_report(bits: int) -> Sequence[int]
 
     # ---------- helpers ----------
 
+    @classmethod
+    def set_shift_light_thresholds(cls, thresholds: Sequence[int]) -> tuple[int, ...]:
+        expected_count = len(cls.DEFAULT_SHIFT_LIGHT_THRESHOLDS)
+        if len(thresholds) != expected_count:
+            cls.SHIFT_LIGHT_THRESHOLDS = tuple(cls.DEFAULT_SHIFT_LIGHT_THRESHOLDS)
+            return tuple(cls.SHIFT_LIGHT_THRESHOLDS)
+
+        normalized = []
+        for index, raw_threshold in enumerate(thresholds):
+            low = 0 if index == 0 else normalized[index - 1] + 1
+            high = 100 - (expected_count - index - 1)
+            threshold = int(raw_threshold)
+            normalized.append(max(low, min(threshold, high)))
+
+        cls.SHIFT_LIGHT_THRESHOLDS = tuple(normalized)
+        return tuple(cls.SHIFT_LIGHT_THRESHOLDS)
+
     @staticmethod
     def _percent_to_bits(pct: float) -> int:
-        return (
-            0b11111 if pct > 84
-            else 0b01111 if pct > 69
-            else 0b00111 if pct > 39
-            else 0b00011 if pct > 19
-            else 0b00001 if pct >  4
-            else 0
-        )
+        bits = 0
+        for index, threshold in enumerate(BaseWheel.SHIFT_LIGHT_THRESHOLDS):
+            if pct >= threshold:
+                bits |= (1 << index)
+        return bits


### PR DESCRIPTION
## Summary
This PR improves runtime usability and realism of RPM LEDs by adding configurable shift-light behavior directly in the UI.

## What’s included
- Added configurable **Shift LEDs (%)** thresholds in UI (5 inputs).
- Persisted shift-light thresholds in settings file.
- Unified preview and wheel LED mapping to use the same threshold logic.
- Added threshold normalization/validation (strictly increasing, clamped range).
- Updated README for all new behavior.

## Config persistence
Settings are stored in:
`~/.config/logitech-rpm-indicator/settings.ini` (or `$XDG_CONFIG_HOME/...`)

New persisted keys:
- `shift_lights.thresholds`

## Testing
Validated with:
- `python -m py_compile main.py games/autodetect.py games/assetto_corsa.py wheels/base.py tests/test_telemetry_parsers.py tests/test_game_autodetect.py tests/test_shift_light_mapping.py`
- `python -m unittest -v tests/test_telemetry_parsers.py tests/test_game_autodetect.py tests/test_shift_light_mapping.py`

All tests pass.