### PR TITLE
Add issue templates, fix archlinux packaging issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,102 @@
+name: Bug report
+description: Report a problem with the Logitech RPM LED Indicator.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please include enough detail to reproduce the issue, especially your wheel model, Linux distribution, install method, and game telemetry settings.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the problem and what you expected to happen instead.
+      placeholder: The LEDs do not react when I start F1 23, even though telemetry is enabled.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List the exact steps that trigger the issue.
+      placeholder: |
+        1. Connect Logitech G29
+        2. Start logitech-rpm-indicator
+        3. Select F1 23
+        4. Click Start
+        5. Launch the game
+    validations:
+      required: true
+
+  - type: dropdown
+    id: game
+    attributes:
+      label: Game
+      options:
+        - Forza Horizon 5
+        - F1 2019
+        - F1 2020
+        - F1 22
+        - F1 23
+        - DiRT Rally 2.0
+        - Automobilista 2
+        - Project CARS
+        - Project CARS 2
+        - Assetto Corsa
+        - Auto-detect mode
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: wheel
+    attributes:
+      label: Wheel model
+      placeholder: Logitech G29, G920, G923, etc.
+    validations:
+      required: true
+
+  - type: input
+    id: distro
+    attributes:
+      label: Linux distribution and version
+      placeholder: Fedora 40, Ubuntu 24.04, Arch Linux, etc.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install_method
+    attributes:
+      label: Install method
+      options:
+        - Debian/Ubuntu package (.deb)
+        - Fedora/RHEL/openSUSE package (.rpm)
+        - Arch package
+        - Source checkout
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: App version or commit
+      description: Use the release version, package version, or git commit hash.
+      placeholder: v1.2.3 or 1a2b3c4
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or terminal output
+      description: Paste any errors from the terminal or package launcher.
+      render: shell
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Add screenshots, videos, hardware notes, or anything else that may help.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Troubleshooting guide
+    url: https://github.com/IvanVojtko/logitech-linux-rpm-led#troubleshooting
+    about: Check setup, telemetry, and Linux device permission notes before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,55 @@
+name: Feature request
+description: Suggest an improvement, supported game, or wheel compatibility update.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: What would you like to see?
+      description: Describe the feature or improvement.
+      placeholder: Add support for another game telemetry format.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: request_type
+    attributes:
+      label: Request type
+      options:
+        - New game support
+        - Wheel compatibility
+        - Telemetry parsing
+        - UI improvement
+        - Packaging or installation
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Why is this useful?
+      description: Explain the use case or problem this would solve.
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Technical details or references
+      description: For new games, include telemetry documentation, UDP format details, ports, screenshots, or links if available.
+      placeholder: |
+        Game:
+        Telemetry protocol:
+        Default UDP port:
+        Documentation link:
+
+  - type: input
+    id: wheel
+    attributes:
+      label: Wheel model, if relevant
+      placeholder: Logitech G29, G920, G923, etc.
+

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -103,7 +103,6 @@ jobs:
           # Arch Linux runtime dependencies.
           ARCH_DEPS=(
             --depends "python"
-            --depends "python-hid"
             --depends "python-gobject"
             --depends "python-cairo"
             --depends "gtk4"
@@ -147,6 +146,8 @@ jobs:
             --url "$REPO_URL" \
             --description "$DESC" \
             --pacman-compression zstd \
+            --pacman-optional-depends "python-hid: HID support via pyhidapi bindings" \
+            --pacman-optional-depends "python-hidapi: HID support via cython-hidapi bindings" \
             "${ARCH_DEPS[@]}" \
             -C pkgroot .
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_hid_backend.py
+++ b/tests/test_hid_backend.py
@@ -1,0 +1,95 @@
+import sys
+import types
+import unittest
+
+from wheels.base import BaseWheel
+from wheels.hid_backend import enumerate_devices, open_device
+
+
+class TestHidBackend(unittest.TestCase):
+    def tearDown(self) -> None:
+        sys.modules.pop("hid", None)
+
+    def test_enumerate_devices_delegates_to_hid_module(self) -> None:
+        fake_hid = types.ModuleType("hid")
+        fake_hid.enumerate = lambda: [{"vendor_id": 0x046d, "product_id": 0xc24f}]
+        sys.modules["hid"] = fake_hid
+
+        self.assertEqual(
+            enumerate_devices(),
+            [{"vendor_id": 0x046d, "product_id": 0xc24f}],
+        )
+
+    def test_open_device_supports_python_hid_api(self) -> None:
+        fake_hid = types.ModuleType("hid")
+
+        class Device:
+            def __init__(self, vendor_id: int, product_id: int) -> None:
+                self.vendor_id = vendor_id
+                self.product_id = product_id
+
+        fake_hid.Device = Device
+        sys.modules["hid"] = fake_hid
+
+        device = open_device(0x046d, 0xc24f)
+
+        self.assertIsInstance(device, Device)
+        self.assertEqual(device.vendor_id, 0x046d)
+        self.assertEqual(device.product_id, 0xc24f)
+
+    def test_open_device_supports_python_hidapi_api(self) -> None:
+        fake_hid = types.ModuleType("hid")
+
+        class Device:
+            def open(self, vendor_id: int, product_id: int) -> None:
+                self.vendor_id = vendor_id
+                self.product_id = product_id
+
+        fake_hid.device = Device
+        sys.modules["hid"] = fake_hid
+
+        device = open_device(0x046d, 0xc266)
+
+        self.assertIsInstance(device, Device)
+        self.assertEqual(device.vendor_id, 0x046d)
+        self.assertEqual(device.product_id, 0xc266)
+
+
+class TestWheelUsbConnection(unittest.TestCase):
+    def tearDown(self) -> None:
+        sys.modules.pop("hid", None)
+
+    def test_connect_tries_next_product_id_after_hid_error(self) -> None:
+        fake_hid = types.ModuleType("hid")
+        fake_hid.HIDException = type("HIDException", (Exception,), {})
+        opened_product_ids = []
+
+        class Device:
+            def __init__(self, vendor_id: int, product_id: int) -> None:
+                opened_product_ids.append(product_id)
+                if product_id == 0x0001:
+                    raise fake_hid.HIDException("not this one")
+                self.vendor_id = vendor_id
+                self.product_id = product_id
+
+            def write(self, data: bytes) -> None:
+                self.last_write = data
+
+        class TestWheel(BaseWheel):
+            PRODUCT_IDS = (0x0001, 0x0002)
+
+            def _led_report(self, bits: int) -> list[int]:
+                return [bits]
+
+        fake_hid.Device = Device
+        sys.modules["hid"] = fake_hid
+
+        wheel = TestWheel()
+
+        self.assertTrue(wheel.connect())
+        self.assertEqual(opened_product_ids, [0x0001, 0x0002])
+        self.assertEqual(wheel._dev.product_id, 0x0002)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wheels/base.py
+++ b/wheels/base.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
-import hid
-from typing import Iterable, Sequence
+from typing import Any, Iterable, Sequence
+
+from wheels.hid_backend import is_hid_error, open_device
 
 
 class BaseWheel(ABC):
@@ -17,18 +18,20 @@ _led_report(bits: int) -> Sequence[int]
     SHIFT_LIGHT_THRESHOLDS: Sequence[int] = DEFAULT_SHIFT_LIGHT_THRESHOLDS
 
     def __init__(self) -> None:
-        self._dev: hid.Device | None = None
+        self._dev: Any | None = None
         self._last_bits: int = -1    # cache to avoid spamming
 
 
     def connect(self) -> bool:
         for pid in self.PRODUCT_IDS:
             try:
-                self._dev = hid.Device(self.VENDOR_ID, pid)
+                self._dev = open_device(self.VENDOR_ID, pid)
                 self._post_connect_setup()
                 return True
-            except hid.HIDException:
-                continue
+            except Exception as error:
+                if is_hid_error(error):
+                    continue
+                raise
         return False
 
     def leds_rpm(self, percent: float) -> None:

--- a/wheels/detect.py
+++ b/wheels/detect.py
@@ -1,8 +1,8 @@
-import hid
 from wheels.wheels import G29
 from wheels.wheels import G923xbox
 from wheels.wheels import G923ps4
 from wheels.base import BaseWheel
+from wheels.hid_backend import enumerate_devices
 
 # Register every VID/PID with its class
 DEVICE_MAP: dict[tuple[int, int], type[BaseWheel]] = {}
@@ -13,7 +13,7 @@ for cls in (G29, G923xbox, G923ps4):
 
 def find_wheel() -> BaseWheel | None:
     """Return a connected wheel instance or None."""
-    for dev in hid.enumerate():
+    for dev in enumerate_devices():
         cls = DEVICE_MAP.get((dev['vendor_id'], dev['product_id']))
         if cls:
             wheel = cls()

--- a/wheels/hid_backend.py
+++ b/wheels/hid_backend.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+
+def _hid() -> Any:
+    return importlib.import_module("hid")
+
+
+def is_hid_error(error: Exception) -> bool:
+    hid = _hid()
+    hid_exception = getattr(hid, "HIDException", None)
+    hid_errors = tuple(
+        error_type
+        for error_type in (hid_exception, OSError)
+        if isinstance(error_type, type)
+    )
+    return isinstance(error, hid_errors)
+
+
+def enumerate_devices() -> list[dict[str, Any]]:
+    hid = _hid()
+    return hid.enumerate()
+
+
+def open_device(vendor_id: int, product_id: int) -> Any:
+    hid = _hid()
+    if hasattr(hid, "Device"):
+        return hid.Device(vendor_id, product_id)
+
+    if hasattr(hid, "device"):
+        device = hid.device()
+        device.open(vendor_id, product_id)
+        return device
+
+    raise RuntimeError("Unsupported Python hid binding")


### PR DESCRIPTION
## Summary

This PR fixes Arch Linux package installation conflicts around Python HID bindings and adds regression coverage for USB/HID backend compatibility.

Arch provides both `python-hid` and `python-hidapi`, and some applications install `python-hidapi`, which conflicts with forcing `python-hid` as a hard dependency. The app now supports both binding APIs, so the Arch package no longer needs to require one specific HID package.

## Changes

- Added a HID compatibility layer in `wheels/hid_backend.py`
- Supports both:
  - `python-hid` style: `hid.Device(vendor_id, product_id)`
  - `python-hidapi` style: `hid.device().open(vendor_id, product_id)`
- Updated wheel connection and detection code to use the compatibility layer
- Changed Arch package metadata:
  - Removed hard dependency on `python-hid`
  - Added `python-hid` and `python-hidapi` as optional dependencies
- Made HID imports lazy so non-USB unit tests do not require HID bindings installed
- Added USB/HID regression tests


## Testing

```bash
pytest -q
21 passed, 4 subtests passed
```