### PR TITLE
Euro Truck Simulator 2

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -36,8 +36,16 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y ruby ruby-dev build-essential rpm zip libarchive-tools zstd
+          sudo apt-get install -y ruby ruby-dev build-essential rpm zip unzip libarchive-tools zstd g++-mingw-w64-x86-64
           sudo gem install --no-document fpm
+
+      - name: Build ETS2 telemetry plugins
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -L https://download.eurotrucksimulator2.com/scs_sdk_1_14.zip -o /tmp/scs_sdk_1_14.zip
+          unzip -q /tmp/scs_sdk_1_14.zip -d /tmp/scs_sdk_1_14
+          make -C scs-plugin SCS_SDK_DIR=/tmp/scs_sdk_1_14
 
       - name: Prepare package root
         shell: bash
@@ -61,6 +69,7 @@ jobs:
           [ -d games ] && cp -a games "$PKGROOT/opt/$APP_NAME/" || true
           [ -d wheels ] && cp -a wheels "$PKGROOT/opt/$APP_NAME/" || true
           [ -d icons ] && cp -a icons "$PKGROOT/opt/$APP_NAME/" || true
+          [ -d scs-plugin ] && cp -a scs-plugin "$PKGROOT/opt/$APP_NAME/" || true
           [ -d scs-plugin ] && cp -a scs-plugin "$PKGROOT/usr/share/doc/$APP_NAME/" || true
 
           # Runner wrapper (installed on PATH)
@@ -110,11 +119,11 @@ jobs:
             --depends "libadwaita"
           )
 
-          # DEB (arch-independent)
+          # DEB
           fpm -s dir -t deb \
             -n "$APP_NAME" \
             -v "$VERSION" \
-            -a all \
+            -a amd64 \
             --iteration 1 \
             --license "GPL-3.0-only" \
             --maintainer "$MAINTAINER" \
@@ -123,11 +132,11 @@ jobs:
             "${DEB_DEPS[@]}" \
             -C pkgroot .
 
-          # RPM (arch-independent)
+          # RPM
           fpm -s dir -t rpm \
             -n "$APP_NAME" \
             -v "$VERSION" \
-            -a noarch \
+            -a x86_64 \
             --iteration 1 \
             --license "GPL-3.0-only" \
             --maintainer "$MAINTAINER" \
@@ -136,11 +145,11 @@ jobs:
             "${RPM_DEPS[@]}" \
             -C pkgroot .
 
-          # Arch Linux pacman package (arch-independent)
+          # Arch Linux pacman package
           fpm -s dir -t pacman \
             -n "$APP_NAME" \
             -v "$VERSION" \
-            -a all \
+            -a x86_64 \
             --iteration 1 \
             --license "GPL-3.0-only" \
             --maintainer "$MAINTAINER" \

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -61,6 +61,7 @@ jobs:
           [ -d games ] && cp -a games "$PKGROOT/opt/$APP_NAME/" || true
           [ -d wheels ] && cp -a wheels "$PKGROOT/opt/$APP_NAME/" || true
           [ -d icons ] && cp -a icons "$PKGROOT/opt/$APP_NAME/" || true
+          [ -d scs-plugin ] && cp -a scs-plugin "$PKGROOT/usr/share/doc/$APP_NAME/" || true
 
           # Runner wrapper (installed on PATH)
           cat > "$PKGROOT/usr/bin/$APP_NAME" <<EOF

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+scs-plugin/*.dll
+scs-plugin/*.so

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This project listens to the game’s telemetry/UDP data output and drives the wh
 - **DiRT Rally 2.0**
 - **SMS Madness Engine games** (e.g., **Automobilista 2**, **Project CARS**, **Project CARS 2**)
 - **Assetto Corsa** (manual max RPM input in app)
+- **Euro Truck Simulator 2** (requires the included SCS telemetry plugin)
 
 ---
 
@@ -180,6 +181,49 @@ python main.py
 2. In this app, select **Assetto Corsa** from the dropdown.
 3. Set **Assetto Max RPM** in the input field to match your current car.
 4. The value is saved automatically and restored on next launch.
+
+---
+
+### Euro Truck Simulator 2
+
+ETS2 does not expose RPM telemetry directly over UDP. It loads native SCS SDK
+plugins from the game directory, so this app includes a small plugin source in
+`scs-plugin/`. The plugin reads `truck.engine.rpm` and the truck `rpm.limit`
+configuration value from the SCS Telemetry SDK, then forwards a local UDP packet
+to this Python app on `127.0.0.1:5607`.
+
+Build and install the plugin:
+
+```bash
+curl -L https://download.eurotrucksimulator2.com/scs_sdk_1_14.zip -o /tmp/scs_sdk_1_14.zip
+unzip /tmp/scs_sdk_1_14.zip -d /tmp/scs_sdk_1_14
+make -C scs-plugin linux SCS_SDK_DIR=/tmp/scs_sdk_1_14
+```
+
+Copy `scs-plugin/logitech_rpm_telemetry.so` into the ETS2 plugin directory:
+
+```text
+<SteamLibrary>/steamapps/common/Euro Truck Simulator 2/bin/linux_x64/plugins/
+```
+
+Create the `plugins` directory if it does not exist, then start ETS2 and select
+**Euro Truck Simulator 2** in this app.
+
+For Proton/Windows ETS2, the same approach needs a Windows DLL build of the
+plugin. Install a MinGW-w64 cross compiler, then run:
+
+```bash
+make -C scs-plugin windows SCS_SDK_DIR=/tmp/scs_sdk_1_14
+```
+
+Copy `scs-plugin/logitech_rpm_telemetry.dll` into:
+
+```text
+<SteamLibrary>/steamapps/common/Euro Truck Simulator 2/bin/win_x64/plugins/
+```
+
+On a system with both compilers installed, `make -C scs-plugin
+SCS_SDK_DIR=/tmp/scs_sdk_1_14` builds both files.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -187,12 +187,19 @@ python main.py
 ### Euro Truck Simulator 2
 
 ETS2 does not expose RPM telemetry directly over UDP. It loads native SCS SDK
-plugins from the game directory, so this app includes a small plugin source in
+plugins from the game directory, so this app includes a small plugin in
 `scs-plugin/`. The plugin reads `truck.engine.rpm` and the truck `rpm.limit`
 configuration value from the SCS Telemetry SDK, then forwards a local UDP packet
 to this Python app on `127.0.0.1:5607`.
 
-Build and install the plugin:
+If you installed this app from a release package, select **Euro Truck Simulator
+2** and click **Install ETS2 Telemetry Plugin**. The app searches your Steam
+libraries and copies the bundled Linux/Windows plugin files into the ETS2
+`plugins` directories.
+
+If you run from source, build the plugin first:
+
+Build the plugin:
 
 ```bash
 curl -L https://download.eurotrucksimulator2.com/scs_sdk_1_14.zip -o /tmp/scs_sdk_1_14.zip

--- a/games/autodetect.py
+++ b/games/autodetect.py
@@ -55,6 +55,15 @@ GAME_SIGNATURES = (
         "steam_app_ids": {"244210"},
         "process_tokens": ("assettocorsa.exe", "assetto corsa"),
     },
+    {
+        "key": "euro_truck_simulator_2",
+        "steam_app_ids": {"227300"},
+        "process_tokens": (
+            "eurotrucks2.exe",
+            "eurotrucks2",
+            "euro truck simulator 2",
+        ),
+    },
 )
 
 

--- a/games/ets2_plugin_installer.py
+++ b/games/ets2_plugin_installer.py
@@ -1,0 +1,102 @@
+import os
+import re
+import shutil
+from pathlib import Path
+
+ETS2_APP_ID = "227300"
+ETS2_DIR_NAME = "Euro Truck Simulator 2"
+PLUGIN_DIR_NAME = "scs-plugin"
+PLUGIN_FILENAMES = (
+    ("linux_x64", "logitech_rpm_telemetry.so"),
+    ("win_x64", "logitech_rpm_telemetry.dll"),
+)
+
+
+def default_steam_roots():
+    home = Path.home()
+    roots = [
+        home / ".local/share/Steam",
+        home / ".steam/steam",
+        home / ".var/app/com.valvesoftware.Steam/.local/share/Steam",
+    ]
+    env_root = os.environ.get("STEAM_DIR")
+    if env_root:
+        roots.insert(0, Path(env_root))
+    return roots
+
+
+def _normalize_vdf_path(raw_path):
+    return raw_path.replace("\\\\", "\\")
+
+
+def discover_steam_libraries(steam_roots=None):
+    libraries = []
+    seen = set()
+
+    def add_library(path):
+        resolved = Path(path).expanduser()
+        key = str(resolved)
+        if key not in seen:
+            seen.add(key)
+            libraries.append(resolved)
+
+    for root in steam_roots or default_steam_roots():
+        root = Path(root).expanduser()
+        add_library(root)
+        vdf_path = root / "steamapps/libraryfolders.vdf"
+        try:
+            content = vdf_path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for match in re.finditer(r'"path"\s+"([^"]+)"', content):
+            add_library(_normalize_vdf_path(match.group(1)))
+
+    return libraries
+
+
+def find_ets2_install_dirs(steam_roots=None):
+    install_dirs = []
+    seen = set()
+    for library in discover_steam_libraries(steam_roots):
+        steamapps = library / "steamapps"
+        manifest = steamapps / f"appmanifest_{ETS2_APP_ID}.acf"
+        install_dir = steamapps / "common" / ETS2_DIR_NAME
+        if not manifest.exists() and not install_dir.exists():
+            continue
+        key = str(install_dir)
+        if key not in seen:
+            seen.add(key)
+            install_dirs.append(install_dir)
+    return install_dirs
+
+
+def find_plugin_binaries(app_dir=None):
+    base_dir = Path(app_dir) if app_dir else Path(__file__).resolve().parents[1]
+    plugin_dir = base_dir / PLUGIN_DIR_NAME
+    binaries = []
+    for platform_dir, filename in PLUGIN_FILENAMES:
+        source = plugin_dir / filename
+        if source.exists():
+            binaries.append((platform_dir, source))
+    return binaries
+
+
+def install_ets2_plugins(steam_roots=None, app_dir=None):
+    install_dirs = find_ets2_install_dirs(steam_roots)
+    if not install_dirs:
+        raise FileNotFoundError("Euro Truck Simulator 2 installation was not found in Steam libraries.")
+
+    plugin_binaries = find_plugin_binaries(app_dir)
+    if not plugin_binaries:
+        raise FileNotFoundError("No built ETS2 plugin binaries were found in scs-plugin/.")
+
+    installed_paths = []
+    for install_dir in install_dirs:
+        for platform_dir, source in plugin_binaries:
+            destination_dir = install_dir / "bin" / platform_dir / "plugins"
+            destination_dir.mkdir(parents=True, exist_ok=True)
+            destination = destination_dir / source.name
+            shutil.copy2(source, destination)
+            installed_paths.append(destination)
+
+    return installed_paths

--- a/games/euro_truck_simulator_2.py
+++ b/games/euro_truck_simulator_2.py
@@ -1,0 +1,39 @@
+import socket
+import struct
+
+BUFFER_SIZE = 64
+PORT = 5607
+
+PACKET_MAGIC = b"LRPM"
+PACKET_VERSION = 1
+PACKET_STRUCT = struct.Struct("<4sBBHff")
+
+
+class EuroTruckSimulator2:
+    def __init__(self):
+        self.ip = "127.0.0.1"
+        self.port = PORT
+
+    def connect(self):
+        udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        udp_socket.bind((self.ip, self.port))
+        return udp_socket
+
+    def read_data(self, udp_socket):
+        data, _addr = udp_socket.recvfrom(BUFFER_SIZE)
+        return data
+
+    def get_rpm_percent(self, data, prev_value) -> int:
+        if len(data) < PACKET_STRUCT.size:
+            return prev_value
+
+        magic, version, running, _reserved, current_rpm, max_rpm = PACKET_STRUCT.unpack_from(data)
+        if magic != PACKET_MAGIC or version != PACKET_VERSION:
+            return prev_value
+        if not running:
+            return 0
+        if current_rpm <= 0:
+            return 0
+        if max_rpm <= 0:
+            return prev_value
+        return int((current_rpm / max_rpm) * 100)

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ from games.dirt_rally_2_0 import DirtRally2
 from games.automobilista_2 import Automobilista2
 from games.assetto_corsa import AssettoCorsa
 from games.euro_truck_simulator_2 import EuroTruckSimulator2
+from games.ets2_plugin_installer import install_ets2_plugins
 from games.autodetect import detect_running_game
 from wheels.base import BaseWheel
 from wheels.detect import find_wheel
@@ -93,6 +94,14 @@ APP_CSS = """
 
 .action-button {
   min-height: 40px;
+}
+
+.success-label {
+  color: #2f8f46;
+}
+
+.warning-label {
+  color: #b26a00;
 }
 
 .rpm-meter {
@@ -259,6 +268,18 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
         self.assetto_max_rpm_row.append(self.assetto_max_rpm_input)
         self.assetto_max_rpm_row.set_visible(False)
         game_panel.append(self.assetto_max_rpm_row)
+
+        self.ets2_plugin_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        self.ets2_plugin_button = Gtk.Button(label="Install ETS2 Telemetry Plugin")
+        self.ets2_plugin_button.add_css_class("action-button")
+        self.ets2_plugin_button.connect("clicked", self._on_ets2_plugin_install_clicked)
+        self.ets2_plugin_status = Gtk.Label()
+        self.ets2_plugin_status.set_xalign(0)
+        self.ets2_plugin_status.set_wrap(True)
+        self.ets2_plugin_box.append(self.ets2_plugin_button)
+        self.ets2_plugin_box.append(self.ets2_plugin_status)
+        self.ets2_plugin_box.set_visible(False)
+        game_panel.append(self.ets2_plugin_box)
 
         self.wheel = find_wheel()
         if not self.wheel:
@@ -465,10 +486,33 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
     def _on_game_selected_changed(self, *_args):
         selected_choice = self.combo.get_selected()
         self.assetto_max_rpm_row.set_visible(selected_choice == ASSETTO_CORSA)
+        self.ets2_plugin_box.set_visible(selected_choice == EURO_TRUCK_SIMULATOR_2)
         if self._is_valid_choice(selected_choice):
             self.last_selected_game_choice = int(selected_choice)
             if self.remember_last_selected_game:
                 self._save_settings()
+
+    def _set_ets2_plugin_status(self, message, css_class):
+        self.ets2_plugin_status.remove_css_class("success-label")
+        self.ets2_plugin_status.remove_css_class("warning-label")
+        self.ets2_plugin_status.add_css_class(css_class)
+        self.ets2_plugin_status.set_text(message)
+
+    def _on_ets2_plugin_install_clicked(self, _button):
+        self.ets2_plugin_button.set_sensitive(False)
+        try:
+            installed_paths = install_ets2_plugins(app_dir=Path(__file__).resolve().parent)
+            if not installed_paths:
+                self._set_ets2_plugin_status("No ETS2 plugin files were installed.", "warning-label")
+                return
+            self._set_ets2_plugin_status(
+                f"Installed {len(installed_paths)} ETS2 plugin file(s). Restart ETS2 if it is already running.",
+                "success-label",
+            )
+        except Exception as exc:
+            self._set_ets2_plugin_status(str(exc), "warning-label")
+        finally:
+            self.ets2_plugin_button.set_sensitive(True)
 
     @staticmethod
     def _percent_to_led_bits(percent):

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ from games.f12023 import F12023
 from games.dirt_rally_2_0 import DirtRally2
 from games.automobilista_2 import Automobilista2
 from games.assetto_corsa import AssettoCorsa
+from games.euro_truck_simulator_2 import EuroTruckSimulator2
 from games.autodetect import detect_running_game
 from wheels.base import BaseWheel
 from wheels.detect import find_wheel
@@ -31,6 +32,7 @@ F1_2023 =           4
 DIRT_RALLY_2_0 =    5
 AMS_2 =             6
 ASSETTO_CORSA =     7
+EURO_TRUCK_SIMULATOR_2 = 8
 
 DEFAULT_ASSETTO_MAX_RPM = 9000
 MIN_ASSETTO_MAX_RPM = 1000
@@ -51,6 +53,7 @@ GAME_KEY_TO_CHOICE = {
     "dirt_rally_2_0": DIRT_RALLY_2_0,
     "ams_2": AMS_2,
     "assetto_corsa": ASSETTO_CORSA,
+    "euro_truck_simulator_2": EURO_TRUCK_SIMULATOR_2,
 }
 
 APP_CSS = """
@@ -205,6 +208,7 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
         self.model_widget.append(Widget(name="Dirt Rally 2.0", image_path='icons/dirt-rally-2-0.png'))
         self.model_widget.append(Widget(name="AMS 2 / pCars / pCars2", image_path='icons/ams-2.png'))
         self.model_widget.append(Widget(name="Assetto Corsa", image_path='icons/asseto.png'))
+        self.model_widget.append(Widget(name="Euro Truck Simulator 2", image_path='icons/ams-2.png'))
         self.combo = Gtk.DropDown(model=self.model_widget, factory=factory_widget)
         self.combo.set_hexpand(True)
         self.combo.set_enable_search(True)
@@ -557,6 +561,8 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
             self.assetto_max_rpm = int(self.assetto_max_rpm_input.get_value())
             self._save_settings()
             return AssettoCorsa(max_rpm=self.assetto_max_rpm)
+        if choice == EURO_TRUCK_SIMULATOR_2:
+            return EuroTruckSimulator2()
         return None
 
     def _start_telemetry_for_choice(self, choice):

--- a/scs-plugin/Makefile
+++ b/scs-plugin/Makefile
@@ -1,0 +1,35 @@
+SCS_SDK_DIR ?= ../scs_sdk_1_14
+
+SDK_INCLUDES := \
+	-I$(SCS_SDK_DIR)/include \
+	-I$(SCS_SDK_DIR)/include/common \
+	-I$(SCS_SDK_DIR)/include/eurotrucks2 \
+	-I$(SCS_SDK_DIR)/include/amtrucks
+
+PLUGIN_SOURCE := logitech_rpm_telemetry.cpp
+LINUX_PLUGIN := logitech_rpm_telemetry.so
+WINDOWS_PLUGIN := logitech_rpm_telemetry.dll
+
+LINUX_CXX ?= g++
+WINDOWS_CXX ?= x86_64-w64-mingw32-g++
+
+COMMON_CXXFLAGS ?= -O2 -Wall -Wextra
+LINUX_CXXFLAGS ?= -fPIC
+WINDOWS_CXXFLAGS ?=
+
+.PHONY: all linux windows clean
+
+all: linux windows
+
+linux: $(LINUX_PLUGIN)
+
+windows: $(WINDOWS_PLUGIN)
+
+$(LINUX_PLUGIN): $(PLUGIN_SOURCE)
+	$(LINUX_CXX) -o $@ --shared $(COMMON_CXXFLAGS) $(LINUX_CXXFLAGS) -Wl,-soname,$@ $(SDK_INCLUDES) $<
+
+$(WINDOWS_PLUGIN): $(PLUGIN_SOURCE)
+	$(WINDOWS_CXX) -o $@ --shared $(COMMON_CXXFLAGS) $(WINDOWS_CXXFLAGS) $(SDK_INCLUDES) $< -lws2_32
+
+clean:
+	rm -f -- $(LINUX_PLUGIN) $(WINDOWS_PLUGIN)

--- a/scs-plugin/logitech_rpm_telemetry.cpp
+++ b/scs-plugin/logitech_rpm_telemetry.cpp
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#ifdef _WIN32
+#  define WINVER 0x0501
+#  define _WIN32_WINNT 0x0501
+#  include <winsock2.h>
+#  include <ws2tcpip.h>
+#else
+#  include <arpa/inet.h>
+#  include <sys/socket.h>
+#  include <unistd.h>
+#endif
+
+#include <cstring>
+
+#include "scssdk_telemetry.h"
+#include "eurotrucks2/scssdk_eut2.h"
+#include "eurotrucks2/scssdk_telemetry_eut2.h"
+
+namespace {
+
+constexpr unsigned short kUdpPort = 5607;
+constexpr char kPacketMagic[4] = {'L', 'R', 'P', 'M'};
+constexpr unsigned char kPacketVersion = 1;
+
+#pragma pack(push, 1)
+struct rpm_packet_t
+{
+	char magic[4];
+	unsigned char version;
+	unsigned char running;
+	unsigned short reserved;
+	float current_rpm;
+	float max_rpm;
+};
+#pragma pack(pop)
+
+float current_rpm = 0.0f;
+float max_rpm = 0.0f;
+bool telemetry_running = false;
+scs_log_t game_log = nullptr;
+
+#ifdef _WIN32
+SOCKET udp_socket = INVALID_SOCKET;
+#else
+int udp_socket = -1;
+#endif
+
+sockaddr_in udp_destination {};
+
+void log_message(const scs_log_type_t type, const char *const text)
+{
+	if (game_log) {
+		game_log(type, text);
+	}
+}
+
+bool initialize_udp()
+{
+#ifdef _WIN32
+	WSADATA wsa_data;
+	if (WSAStartup(MAKEWORD(2, 2), &wsa_data) != 0) {
+		return false;
+	}
+	udp_socket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	if (udp_socket == INVALID_SOCKET) {
+		WSACleanup();
+		return false;
+	}
+#else
+	udp_socket = socket(AF_INET, SOCK_DGRAM, 0);
+	if (udp_socket < 0) {
+		return false;
+	}
+#endif
+
+	std::memset(&udp_destination, 0, sizeof(udp_destination));
+	udp_destination.sin_family = AF_INET;
+	udp_destination.sin_port = htons(kUdpPort);
+	udp_destination.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	return true;
+}
+
+void shutdown_udp()
+{
+#ifdef _WIN32
+	if (udp_socket != INVALID_SOCKET) {
+		closesocket(udp_socket);
+		udp_socket = INVALID_SOCKET;
+	}
+	WSACleanup();
+#else
+	if (udp_socket >= 0) {
+		close(udp_socket);
+		udp_socket = -1;
+	}
+#endif
+}
+
+void send_rpm_packet()
+{
+#ifdef _WIN32
+	if (udp_socket == INVALID_SOCKET) {
+		return;
+	}
+#else
+	if (udp_socket < 0) {
+		return;
+	}
+#endif
+
+	rpm_packet_t packet {};
+	std::memcpy(packet.magic, kPacketMagic, sizeof(packet.magic));
+	packet.version = kPacketVersion;
+	packet.running = telemetry_running ? 1 : 0;
+	packet.current_rpm = current_rpm;
+	packet.max_rpm = max_rpm;
+
+	sendto(
+		udp_socket,
+		reinterpret_cast<const char *>(&packet),
+		sizeof(packet),
+		0,
+		reinterpret_cast<const sockaddr *>(&udp_destination),
+		sizeof(udp_destination)
+	);
+}
+
+const scs_named_value_t *find_attribute(
+	const scs_telemetry_configuration_t &configuration,
+	const char *const name,
+	const scs_value_type_t expected_type
+)
+{
+	for (const scs_named_value_t *current = configuration.attributes; current->name; ++current) {
+		if ((current->index != SCS_U32_NIL) || (std::strcmp(current->name, name) != 0)) {
+			continue;
+		}
+		if (current->value.type == expected_type) {
+			return current;
+		}
+		return nullptr;
+	}
+	return nullptr;
+}
+
+SCSAPI_VOID telemetry_pause(
+	const scs_event_t event,
+	const void *const,
+	const scs_context_t
+)
+{
+	telemetry_running = (event == SCS_TELEMETRY_EVENT_started);
+	if (!telemetry_running) {
+		current_rpm = 0.0f;
+	}
+	send_rpm_packet();
+}
+
+SCSAPI_VOID telemetry_configuration(
+	const scs_event_t,
+	const void *const event_info,
+	const scs_context_t
+)
+{
+	const auto *const info = static_cast<const scs_telemetry_configuration_t *>(event_info);
+	if (std::strcmp(info->id, SCS_TELEMETRY_CONFIG_truck) != 0) {
+		return;
+	}
+
+	const scs_named_value_t *const rpm_limit = find_attribute(
+		*info,
+		SCS_TELEMETRY_CONFIG_ATTRIBUTE_rpm_limit,
+		SCS_VALUE_TYPE_float
+	);
+	max_rpm = rpm_limit ? rpm_limit->value.value_float.value : 0.0f;
+	send_rpm_packet();
+}
+
+SCSAPI_VOID telemetry_store_rpm(
+	const scs_string_t,
+	const scs_u32_t,
+	const scs_value_t *const value,
+	const scs_context_t
+)
+{
+	if (!value || value->type != SCS_VALUE_TYPE_float) {
+		current_rpm = 0.0f;
+	} else {
+		current_rpm = value->value_float.value;
+	}
+	send_rpm_packet();
+}
+
+} // namespace
+
+SCSAPI_RESULT scs_telemetry_init(
+	const scs_u32_t version,
+	const scs_telemetry_init_params_t *const params
+)
+{
+	if (version != SCS_TELEMETRY_VERSION_1_01) {
+		return SCS_RESULT_unsupported;
+	}
+
+	const auto *const version_params = static_cast<const scs_telemetry_init_params_v101_t *>(params);
+	game_log = version_params->common.log;
+
+	if (std::strcmp(version_params->common.game_id, SCS_GAME_ID_EUT2) != 0) {
+		log_message(SCS_LOG_TYPE_warning, "Logitech RPM telemetry plugin loaded by a non-ETS2 SCS game.");
+	}
+
+	if (!initialize_udp()) {
+		log_message(SCS_LOG_TYPE_error, "Logitech RPM telemetry plugin failed to open UDP socket.");
+		game_log = nullptr;
+		return SCS_RESULT_generic_error;
+	}
+
+	const bool events_registered =
+		(version_params->register_for_event(SCS_TELEMETRY_EVENT_paused, telemetry_pause, nullptr) == SCS_RESULT_ok) &&
+		(version_params->register_for_event(SCS_TELEMETRY_EVENT_started, telemetry_pause, nullptr) == SCS_RESULT_ok) &&
+		(version_params->register_for_event(SCS_TELEMETRY_EVENT_configuration, telemetry_configuration, nullptr) == SCS_RESULT_ok);
+	if (!events_registered) {
+		shutdown_udp();
+		game_log = nullptr;
+		return SCS_RESULT_generic_error;
+	}
+
+	version_params->register_for_channel(
+		SCS_TELEMETRY_TRUCK_CHANNEL_engine_rpm,
+		SCS_U32_NIL,
+		SCS_VALUE_TYPE_float,
+		SCS_TELEMETRY_CHANNEL_FLAG_no_value,
+		telemetry_store_rpm,
+		nullptr
+	);
+
+	current_rpm = 0.0f;
+	max_rpm = 0.0f;
+	telemetry_running = false;
+	send_rpm_packet();
+	log_message(SCS_LOG_TYPE_message, "Logitech RPM telemetry plugin initialized.");
+	return SCS_RESULT_ok;
+}
+
+SCSAPI_VOID scs_telemetry_shutdown(void)
+{
+	telemetry_running = false;
+	current_rpm = 0.0f;
+	send_rpm_packet();
+	shutdown_udp();
+	game_log = nullptr;
+}

--- a/tests/test_ets2_plugin_installer.py
+++ b/tests/test_ets2_plugin_installer.py
@@ -1,0 +1,72 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from games.ets2_plugin_installer import (
+    discover_steam_libraries,
+    find_ets2_install_dirs,
+    find_plugin_binaries,
+    install_ets2_plugins,
+)
+
+
+class TestEts2PluginInstaller(unittest.TestCase):
+    def test_discovers_libraryfolders_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "Steam"
+            extra = Path(temp_dir) / "Library"
+            (root / "steamapps").mkdir(parents=True)
+            (root / "steamapps/libraryfolders.vdf").write_text(
+                f'"libraryfolders"\n{{\n  "1"\n  {{\n    "path"\t"{extra}"\n  }}\n}}\n',
+                encoding="utf-8",
+            )
+
+            self.assertEqual(discover_steam_libraries([root]), [root, extra])
+
+    def test_finds_ets2_install_dir_from_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "Steam"
+            steamapps = root / "steamapps"
+            install_dir = steamapps / "common" / "Euro Truck Simulator 2"
+            steamapps.mkdir(parents=True)
+            (steamapps / "appmanifest_227300.acf").write_text("", encoding="utf-8")
+
+            self.assertEqual(find_ets2_install_dirs([root]), [install_dir])
+
+    def test_finds_available_plugin_binaries(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            app_dir = Path(temp_dir)
+            plugin_dir = app_dir / "scs-plugin"
+            plugin_dir.mkdir()
+            linux_plugin = plugin_dir / "logitech_rpm_telemetry.so"
+            linux_plugin.write_bytes(b"plugin")
+
+            self.assertEqual(find_plugin_binaries(app_dir), [("linux_x64", linux_plugin)])
+
+    def test_installs_available_plugins(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "Steam"
+            steamapps = root / "steamapps"
+            install_dir = steamapps / "common" / "Euro Truck Simulator 2"
+            steamapps.mkdir(parents=True)
+            install_dir.mkdir(parents=True)
+
+            app_dir = Path(temp_dir) / "app"
+            plugin_dir = app_dir / "scs-plugin"
+            plugin_dir.mkdir(parents=True)
+            linux_plugin = plugin_dir / "logitech_rpm_telemetry.so"
+            windows_plugin = plugin_dir / "logitech_rpm_telemetry.dll"
+            linux_plugin.write_bytes(b"linux")
+            windows_plugin.write_bytes(b"windows")
+
+            installed_paths = install_ets2_plugins(steam_roots=[root], app_dir=app_dir)
+
+            expected_linux = install_dir / "bin/linux_x64/plugins/logitech_rpm_telemetry.so"
+            expected_windows = install_dir / "bin/win_x64/plugins/logitech_rpm_telemetry.dll"
+            self.assertEqual(installed_paths, [expected_linux, expected_windows])
+            self.assertEqual(expected_linux.read_bytes(), b"linux")
+            self.assertEqual(expected_windows.read_bytes(), b"windows")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_game_autodetect.py
+++ b/tests/test_game_autodetect.py
@@ -21,6 +21,13 @@ class TestGameAutoDetect(unittest.TestCase):
         ]
         self.assertEqual(detect_game_from_processes(processes), "f1_2023")
 
+    def test_detects_ets2_by_steam_app_id(self) -> None:
+        processes = [
+            {"name": "steam", "cmdline": "steam", "steam_app_id": ""},
+            {"name": "eurotrucks2.exe", "cmdline": "", "steam_app_id": "227300"},
+        ]
+        self.assertEqual(detect_game_from_processes(processes), "euro_truck_simulator_2")
+
     def test_returns_none_when_no_match(self) -> None:
         processes = [
             {"name": "steam", "cmdline": "steamwebhelper", "steam_app_id": ""},

--- a/tests/test_telemetry_parsers.py
+++ b/tests/test_telemetry_parsers.py
@@ -22,6 +22,10 @@ from games.f12023 import PACKET_ID_POS as F12023_PACKET_ID_POS
 from games.f12023 import PLAYER_CAR_INDEX_POS as F12023_PLAYER_CAR_INDEX_POS
 from games.f12023 import F12023
 from games.forza_horizon import ForzaHorizon5
+from games.euro_truck_simulator_2 import PACKET_MAGIC as ETS2_PACKET_MAGIC
+from games.euro_truck_simulator_2 import PACKET_STRUCT as ETS2_PACKET_STRUCT
+from games.euro_truck_simulator_2 import PACKET_VERSION as ETS2_PACKET_VERSION
+from games.euro_truck_simulator_2 import EuroTruckSimulator2
 
 
 def _field_count(fmt: str) -> int:
@@ -105,6 +109,28 @@ class TestAssettoCorsaParser(unittest.TestCase):
         packet[AC_PACKET_SIZE_POS:AC_PACKET_SIZE_POS + 4] = struct.pack("<i", len(packet))
         packet[AC_CURRENT_RPM_POS:AC_CURRENT_RPM_POS + 4] = struct.pack("<f", 0.0)
         self.assertEqual(game.get_rpm_percent(bytes(packet), 73), 0)
+
+
+class TestEuroTruckSimulator2Parser(unittest.TestCase):
+    def test_valid_packet_computes_percent(self) -> None:
+        game = EuroTruckSimulator2()
+        packet = ETS2_PACKET_STRUCT.pack(ETS2_PACKET_MAGIC, ETS2_PACKET_VERSION, 1, 0, 1050.0, 2100.0)
+        self.assertEqual(game.get_rpm_percent(packet, 7), 50)
+
+    def test_paused_packet_returns_zero(self) -> None:
+        game = EuroTruckSimulator2()
+        packet = ETS2_PACKET_STRUCT.pack(ETS2_PACKET_MAGIC, ETS2_PACKET_VERSION, 0, 0, 1050.0, 2100.0)
+        self.assertEqual(game.get_rpm_percent(packet, 73), 0)
+
+    def test_invalid_packet_returns_previous_percent(self) -> None:
+        game = EuroTruckSimulator2()
+        packet = ETS2_PACKET_STRUCT.pack(b"BAD!", ETS2_PACKET_VERSION, 1, 0, 1050.0, 2100.0)
+        self.assertEqual(game.get_rpm_percent(packet, 41), 41)
+
+    def test_missing_max_rpm_returns_previous_percent(self) -> None:
+        game = EuroTruckSimulator2()
+        packet = ETS2_PACKET_STRUCT.pack(ETS2_PACKET_MAGIC, ETS2_PACKET_VERSION, 1, 0, 1050.0, 0.0)
+        self.assertEqual(game.get_rpm_percent(packet, 23), 23)
 
 
 class TestF1PlayerCarSelection(unittest.TestCase):


### PR DESCRIPTION
**Title**
Add Euro Truck Simulator 2 telemetry support via SCS plugin

**Description**
Adds ETS2 support by introducing a native SCS telemetry plugin that forwards engine RPM data to the Python app over localhost UDP.

**Changes**
- Add `EuroTruckSimulator2` telemetry parser for local UDP packets on `127.0.0.1:5607`
- Add SCS telemetry plugin source under `scs-plugin/`
- Add Makefile targets for Linux `.so` and Windows/Proton `.dll`
- Add ETS2 to game dropdown and process auto-detection
- Add in-app ETS2 plugin installer button
- Add Steam library discovery and plugin installation helper
- Package built ETS2 plugin binaries with release packages
- Update README with ETS2 setup instructions
- Add parser, autodetect, and plugin installer tests

**Testing**
- `python -m pytest`
- `make -C scs-plugin linux SCS_SDK_DIR=/tmp/scs_sdk_1_14`

**Notes**
- Release packages are now architecture-specific because they include native ETS2 plugin binaries.
- Windows/Proton DLL builds require `x86_64-w64-mingw32-g++`.