### PR TITLE
Add G27 wheel support and G Pro and RS50 experimental support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -56,7 +56,7 @@ body:
     id: wheel
     attributes:
       label: Wheel model
-      placeholder: Logitech G29, G920, G923, etc.
+      placeholder: Logitech G27, G29, G923, etc.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -51,5 +51,5 @@ body:
     id: wheel
     attributes:
       label: Wheel model, if relevant
-      placeholder: Logitech G29, G920, G923, etc.
+      placeholder: Logitech G27, G29, G923, etc.
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ If you like my work, consider supporting me:
 - **Euro Truck Simulator 2** (requires the included SCS telemetry plugin)
 - **Wreckfest 2**
 
+## Supported Wheels
+
+Only the following Logitech wheels are supported at the moment.
+
+- **G27**
+- **G29**
+- **G923, Xbox and Playstation variants**
+- **G Pro, Xbox and Playstation variants** <ins>This is untested!</ins> Please open an issue if you encounter problems
+- **RS50** <ins>This is untested!</ins> Please open an issue if you encounter problems.
+
 ---
 
 ## Installation

--- a/wheels/detect.py
+++ b/wheels/detect.py
@@ -1,12 +1,16 @@
+from wheels.wheels import G27
 from wheels.wheels import G29
 from wheels.wheels import G923xbox
 from wheels.wheels import G923ps4
+from wheels.wheels import GPROxbox
+from wheels.wheels import GPROps4
+from wheels.wheels import RS50
 from wheels.base import BaseWheel
 from wheels.hid_backend import enumerate_devices
 
 # Register every VID/PID with its class
 DEVICE_MAP: dict[tuple[int, int], type[BaseWheel]] = {}
-for cls in (G29, G923xbox, G923ps4):
+for cls in (G27, G29, G923xbox, G923ps4, GPROxbox, GPROps4, RS50):
     for pid in cls.PRODUCT_IDS:
         DEVICE_MAP[(cls.VENDOR_ID, pid)] = cls
 

--- a/wheels/hid_backend.py
+++ b/wheels/hid_backend.py
@@ -30,6 +30,7 @@ def open_device(vendor_id: int, product_id: int) -> Any:
         return hid.Device(vendor_id, product_id)
 
     if hasattr(hid, "device"):
+        print("Warning: Falling back to alternative HID interface, this may not work for your wheel")
         device = hid.device()
         device.open(vendor_id, product_id)
         return device

--- a/wheels/wheels.py
+++ b/wheels/wheels.py
@@ -1,11 +1,26 @@
 from wheels.protocols import HIDClassic
 from wheels.protocols import HIDpp
 
+class G27(HIDClassic):
+    PRODUCT_IDS = (0xC294, 0xC29B)   # Driving Force Compatibility/Native variant
+
 class G29(HIDClassic):
     PRODUCT_IDS = (0xC24F, 0xC260)   # PS3 / PS4 variants
 
 class G923xbox(HIDpp):
-    PRODUCT_IDS = [0xC26E]   # Xbox variant
+    PRODUCT_IDS = (0xC26E, 0xC266)   # Xbox variant
 
 class G923ps4(HIDClassic):
     PRODUCT_IDS = [0xC267]   # PS4 variant
+
+# UNTESTED!
+class GPROxbox(HIDpp):
+    PRODUCT_IDS = [0xC268]   # Xbox variant
+
+# UNTESTED!
+class GPROps4(HIDClassic):
+    PRODUCT_IDS = [0xC272]   # PS4 variant
+
+# UNTESTED!
+class RS50(HIDpp):
+    PRODUCT_IDS = [0xC276]


### PR DESCRIPTION
I tested with G27. I added G Pro and RS50 too, but do not have the devices to test. I figured it could not hurt to add them too, just in case it works as is.