### PR TITLE
Correct PlayStation variant LED protocol and startup crash

### DIFF
--- a/games/wreckfest_2.py
+++ b/games/wreckfest_2.py
@@ -32,6 +32,10 @@ class Wreckfest2:
         return rpm_percent
 
     def get_rpm_percent(self, data, percent) -> int:
+        if len(data) < 5:
+            print("ERROR: Packet was too small, cannot extract RPM")
+            return percent
+
         signature = int.from_bytes(data[0:4], byteorder='little', signed=False)
         packetType = data[4]
         if signature != 1869769584:

--- a/main.py
+++ b/main.py
@@ -251,9 +251,6 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
         self.remember_last_game_checkbox.connect("toggled", self._on_remember_last_game_toggled)
         game_panel.append(self.remember_last_game_checkbox)
 
-        if self.remember_last_selected_game and self._is_valid_choice(self.last_selected_game_choice):
-            self.combo.set_selected(self.last_selected_game_choice)
-
         self.shift_light_threshold_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         self.shift_light_threshold_label = Gtk.Label(label="Shift LEDs (%)")
         self.shift_light_threshold_label.set_xalign(0)
@@ -312,6 +309,12 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
         ats_plugin_box.append(self.ats_plugin_button)
         ats_plugin_box.append(self.ats_plugin_status)
         self.ts_plugin_boxes.append(ats_plugin_box)
+
+        # Restore the saved selection only once every widget the handler touches
+        # exists, otherwise "notify::selected" fires against a half-built window.
+        if self.remember_last_selected_game and self._is_valid_choice(self.last_selected_game_choice):
+            self.combo.set_selected(self.last_selected_game_choice)
+        self._on_game_selected_changed()
 
         self.wheel = find_wheel()
         if not self.wheel:
@@ -776,11 +779,15 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
                 continue
 
             last_packet_time = time.monotonic()
-            if choice in (FORZA_HORIZON_5, FORZA_HORIZON_6):
-                max_rpm, current_rpm = game.parse_rpm(data=data)
-                percent = game.get_rpm_percent(max_rpm=max_rpm, current_rpm=current_rpm)
-            else:
-                percent = game.get_rpm_percent(data, percent)
+            try:
+                if choice in (FORZA_HORIZON_5, FORZA_HORIZON_6):
+                    max_rpm, current_rpm = game.parse_rpm(data=data)
+                    percent = game.get_rpm_percent(max_rpm=max_rpm, current_rpm=current_rpm)
+                else:
+                    percent = game.get_rpm_percent(data, percent)
+            except Exception as exc:
+                print(f"Telemetry parse failed, ignoring packet: {exc}")
+                continue
             clamped_percent = max(0, min(int(percent), 100))
             self.shared_rpm_percent = clamped_percent
             now = time.perf_counter()

--- a/tests/test_hid_backend.py
+++ b/tests/test_hid_backend.py
@@ -1,14 +1,32 @@
 import sys
 import types
 import unittest
+from unittest import mock
 
 from wheels.base import BaseWheel
-from wheels.hid_backend import enumerate_devices, open_device
+from wheels.hid_backend import HidBackendUnavailable, enumerate_devices, is_hid_error, open_device
 
 
 class TestHidBackend(unittest.TestCase):
     def tearDown(self) -> None:
         sys.modules.pop("hid", None)
+
+    def test_enumerate_devices_returns_empty_list_when_hid_module_missing(self) -> None:
+        sys.modules.pop("hid", None)
+        with mock.patch(
+            "wheels.hid_backend.importlib.import_module",
+            side_effect=ModuleNotFoundError("No module named 'hid'"),
+        ):
+            self.assertEqual(enumerate_devices(), [])
+
+    def test_is_hid_error_true_when_hid_module_missing(self) -> None:
+        sys.modules.pop("hid", None)
+        with mock.patch(
+            "wheels.hid_backend.importlib.import_module",
+            side_effect=ModuleNotFoundError("No module named 'hid'"),
+        ):
+            self.assertTrue(is_hid_error(HidBackendUnavailable("missing")))
+            self.assertTrue(is_hid_error(OSError("permission denied")))
 
     def test_enumerate_devices_delegates_to_hid_module(self) -> None:
         fake_hid = types.ModuleType("hid")
@@ -89,6 +107,22 @@ class TestWheelUsbConnection(unittest.TestCase):
         self.assertTrue(wheel.connect())
         self.assertEqual(opened_product_ids, [0x0001, 0x0002])
         self.assertEqual(wheel._dev.product_id, 0x0002)
+
+    def test_connect_returns_false_instead_of_raising_when_hid_module_missing(self) -> None:
+        sys.modules.pop("hid", None)
+
+        class TestWheel(BaseWheel):
+            PRODUCT_IDS = (0x0001, 0x0002)
+
+            def _led_report(self, bits: int) -> list[int]:
+                return [bits]
+
+        with mock.patch(
+            "wheels.hid_backend.importlib.import_module",
+            side_effect=ModuleNotFoundError("No module named 'hid'"),
+        ):
+            wheel = TestWheel()
+            self.assertFalse(wheel.connect())
 
 
 if __name__ == "__main__":

--- a/tests/test_telemetry_parsers.py
+++ b/tests/test_telemetry_parsers.py
@@ -211,6 +211,12 @@ class TestWreckfest2Parser(unittest.TestCase):
         game = Wreckfest2()
         self.assertEqual(game.get_rpm_percent(b"\x00" * WRECKFEST_2_MAX_POS, 37), 37)
 
+    def test_truncated_packet_under_five_bytes_does_not_raise(self) -> None:
+        game = Wreckfest2()
+        for size in range(0, 5):
+            with self.subTest(size=size):
+                self.assertEqual(game.get_rpm_percent(b"\x00" * size, 37), 37)
+
     def test_invalid_signed_packet_returns_previous_percent(self) -> None:
         game = Wreckfest2()
         values= [b'\x00'] * 500

--- a/tests/test_wheel_detection.py
+++ b/tests/test_wheel_detection.py
@@ -1,0 +1,117 @@
+import unittest
+from unittest import mock
+
+from wheels.base import BaseWheel
+from wheels.detect import DEVICE_MAP, find_wheel
+from wheels.protocols import HIDClassic, HIDpp
+from wheels.wheels import G923ps, G923xbox
+
+LOGITECH = 0x046D
+
+
+class FakeDevice:
+    def __init__(self, product_id: int, write_error: Exception | None = None) -> None:
+        self.product_id = product_id
+        self.writes: list[bytes] = []
+        self.closed = False
+        self._write_error = write_error
+
+    def write(self, data: bytes) -> None:
+        if self._write_error is not None:
+            raise self._write_error
+        self.writes.append(data)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class TestDeviceMap(unittest.TestCase):
+    def test_g923_playstation_variant_uses_classic_led_protocol(self) -> None:
+        # 0xC266 is the PS wheel in PC mode, 0xC267 the same wheel in PS4 mode.
+        # Both take the classic 0xF8 0x12 rev light report, not HID++.
+        for product_id in (0xC266, 0xC267):
+            with self.subTest(product_id=hex(product_id)):
+                self.assertIs(DEVICE_MAP[(LOGITECH, product_id)], G923ps)
+                self.assertTrue(issubclass(G923ps, HIDClassic))
+
+    def test_g923_xbox_variant_uses_hidpp(self) -> None:
+        self.assertIs(DEVICE_MAP[(LOGITECH, 0xC26E)], G923xbox)
+        self.assertTrue(issubclass(G923xbox, HIDpp))
+
+    def test_g923_led_report_matches_classic_format(self) -> None:
+        self.assertEqual(
+            tuple(G923ps()._led_report(0b00111)),
+            (0xF8, 0x12, 0b00111, 0x00, 0x00, 0x00, 0x01),
+        )
+
+
+class TestFindWheel(unittest.TestCase):
+    def test_only_the_enumerated_product_id_is_opened(self) -> None:
+        opened: list[int] = []
+
+        def fake_open(vendor_id: int, product_id: int) -> FakeDevice:
+            opened.append(product_id)
+            return FakeDevice(product_id)
+
+        with mock.patch(
+            "wheels.detect.enumerate_devices",
+            return_value=[{"vendor_id": LOGITECH, "product_id": 0xC266}],
+        ), mock.patch("wheels.base.open_device", side_effect=fake_open):
+            wheel = find_wheel()
+
+        self.assertIsInstance(wheel, G923ps)
+        self.assertEqual(opened, [0xC266])
+
+    def test_open_failure_is_reported_instead_of_silently_ignored(self) -> None:
+        with mock.patch(
+            "wheels.detect.enumerate_devices",
+            return_value=[{"vendor_id": LOGITECH, "product_id": 0xC266}],
+        ), mock.patch(
+            "wheels.base.open_device", side_effect=OSError("Permission denied")
+        ), mock.patch("builtins.print") as fake_print:
+            self.assertIsNone(find_wheel())
+
+        printed = " ".join(str(call.args[0]) for call in fake_print.call_args_list)
+        self.assertIn("0xc266", printed)
+        self.assertIn("Permission denied", printed)
+
+
+class TestConnectCleanup(unittest.TestCase):
+    def test_device_is_closed_when_post_connect_setup_fails(self) -> None:
+        device = FakeDevice(0xC26E, write_error=OSError("wrong protocol"))
+
+        class TestWheel(HIDpp):
+            PRODUCT_IDS = [0xC26E]
+
+        with mock.patch("wheels.base.open_device", return_value=device):
+            wheel = TestWheel()
+            self.assertFalse(wheel.connect())
+
+        self.assertTrue(device.closed)
+        self.assertIsNone(wheel._dev)
+        self.assertIsInstance(wheel.last_error, OSError)
+
+    def test_connect_without_product_id_still_tries_every_id(self) -> None:
+        opened: list[int] = []
+
+        def fake_open(vendor_id: int, product_id: int) -> FakeDevice:
+            opened.append(product_id)
+            if product_id == 0x0001:
+                raise OSError("not connected")
+            return FakeDevice(product_id)
+
+        class TestWheel(BaseWheel):
+            PRODUCT_IDS = (0x0001, 0x0002)
+
+            def _led_report(self, bits: int) -> list[int]:
+                return [bits]
+
+        with mock.patch("wheels.base.open_device", side_effect=fake_open):
+            wheel = TestWheel()
+            self.assertTrue(wheel.connect())
+
+        self.assertEqual(opened, [0x0001, 0x0002])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wheels/base.py
+++ b/wheels/base.py
@@ -20,19 +20,43 @@ _led_report(bits: int) -> Sequence[int]
     def __init__(self) -> None:
         self._dev: Any | None = None
         self._last_bits: int = -1    # cache to avoid spamming
+        self.last_error: Exception | None = None
 
 
-    def connect(self) -> bool:
-        for pid in self.PRODUCT_IDS:
+    def connect(self, product_id: int | None = None) -> bool:
+        """Open the wheel, optionally restricted to an already enumerated product id."""
+        product_ids = (product_id,) if product_id is not None else tuple(self.PRODUCT_IDS)
+        self.last_error = None
+        for pid in product_ids:
             try:
                 self._dev = open_device(self.VENDOR_ID, pid)
-                self._post_connect_setup()
-                return True
             except Exception as error:
                 if is_hid_error(error):
+                    self.last_error = error
                     continue
                 raise
+            try:
+                self._post_connect_setup()
+            except Exception as error:
+                if not is_hid_error(error):
+                    raise
+                # The device opened but does not speak this protocol: drop it so a
+                # stale handle is not kept around and try the next product id.
+                self.last_error = error
+                self._close_device()
+                continue
+            return True
         return False
+
+    def _close_device(self) -> None:
+        device, self._dev = self._dev, None
+        close = getattr(device, "close", None)
+        if not callable(close):
+            return
+        try:
+            close()
+        except Exception:
+            pass
 
     def leds_rpm(self, percent: float) -> None:
         bits = self._percent_to_bits(percent)

--- a/wheels/detect.py
+++ b/wheels/detect.py
@@ -1,7 +1,7 @@
 from wheels.wheels import G27
 from wheels.wheels import G29
 from wheels.wheels import G923xbox
-from wheels.wheels import G923ps4
+from wheels.wheels import G923ps
 from wheels.wheels import GPROxbox
 from wheels.wheels import GPROps4
 from wheels.wheels import RS50
@@ -10,19 +10,28 @@ from wheels.hid_backend import enumerate_devices
 
 # Register every VID/PID with its class
 DEVICE_MAP: dict[tuple[int, int], type[BaseWheel]] = {}
-for cls in (G27, G29, G923xbox, G923ps4, GPROxbox, GPROps4, RS50):
+for cls in (G27, G29, G923xbox, G923ps, GPROxbox, GPROps4, RS50):
     for pid in cls.PRODUCT_IDS:
         DEVICE_MAP[(cls.VENDOR_ID, pid)] = cls
 
 
 def find_wheel() -> BaseWheel | None:
     """Return a connected wheel instance or None."""
+    failures: list[tuple[str, int, Exception | None]] = []
     for dev in enumerate_devices():
         cls = DEVICE_MAP.get((dev['vendor_id'], dev['product_id']))
-        if cls:
-            wheel = cls()
-            if wheel.connect():
-                print(f"✔  {cls.__name__} detected "
-                      f"({hex(dev['product_id'])})")
-                return wheel
+        if not cls:
+            continue
+        wheel = cls()
+        if wheel.connect(dev['product_id']):
+            print(f"✔  {cls.__name__} detected "
+                  f"({hex(dev['product_id'])})")
+            return wheel
+        failures.append((cls.__name__, dev['product_id'], wheel.last_error))
+
+    for name, product_id, error in failures:
+        print(f"✖  {name} ({hex(product_id)}) was found but could not be opened: {error}")
+    if failures:
+        print("   Check that no other application is using the wheel and that you have "
+              "hidraw permissions (see the udev rule in the README).")
     return None

--- a/wheels/hid_backend.py
+++ b/wheels/hid_backend.py
@@ -4,12 +4,27 @@ import importlib
 from typing import Any
 
 
+class HidBackendUnavailable(RuntimeError):
+    """Raised when the `hid` python package cannot be imported."""
+
+
+_warned_about_legacy_binding = False
+
+
 def _hid() -> Any:
-    return importlib.import_module("hid")
+    try:
+        return importlib.import_module("hid")
+    except Exception as error:
+        raise HidBackendUnavailable(str(error)) from error
 
 
 def is_hid_error(error: Exception) -> bool:
-    hid = _hid()
+    if isinstance(error, HidBackendUnavailable):
+        return True
+    try:
+        hid = _hid()
+    except HidBackendUnavailable:
+        return isinstance(error, OSError)
     hid_exception = getattr(hid, "HIDException", None)
     hid_errors = tuple(
         error_type
@@ -20,7 +35,10 @@ def is_hid_error(error: Exception) -> bool:
 
 
 def enumerate_devices() -> list[dict[str, Any]]:
-    hid = _hid()
+    try:
+        hid = _hid()
+    except HidBackendUnavailable:
+        return []
     return hid.enumerate()
 
 
@@ -30,7 +48,10 @@ def open_device(vendor_id: int, product_id: int) -> Any:
         return hid.Device(vendor_id, product_id)
 
     if hasattr(hid, "device"):
-        print("Warning: Falling back to alternative HID interface, this may not work for your wheel")
+        global _warned_about_legacy_binding
+        if not _warned_about_legacy_binding:
+            print("Warning: Falling back to alternative HID interface, this may not work for your wheel")
+            _warned_about_legacy_binding = True
         device = hid.device()
         device.open(vendor_id, product_id)
         return device

--- a/wheels/wheels.py
+++ b/wheels/wheels.py
@@ -8,10 +8,12 @@ class G29(HIDClassic):
     PRODUCT_IDS = (0xC24F, 0xC260)   # PS3 / PS4 variants
 
 class G923xbox(HIDpp):
-    PRODUCT_IDS = (0xC26E, 0xC266)   # Xbox variant
+    PRODUCT_IDS = [0xC26E]   # Xbox variant
 
-class G923ps4(HIDClassic):
-    PRODUCT_IDS = [0xC267]   # PS4 variant
+class G923ps(HIDClassic):
+    # PlayStation variant: 0xC266 is PC (native) mode, 0xC267 is PS4 mode.
+    # Both drive the rev lights with the classic 0xF8 0x12 report, like the G29.
+    PRODUCT_IDS = (0xC266, 0xC267)
 
 # UNTESTED!
 class GPROxbox(HIDpp):


### PR DESCRIPTION
0xC266 (PS wheel in PC mode) was mapped to the HID++ Xbox class, so its LEDs never lit and detection reported no wheel found. It takes the same classic 0xF8 0x12 report as the G29, so move 0xC266/0xC267 to G923ps.

Also fix the AttributeError on startup: restoring a saved game fired the dropdown handler before the widgets it toggles existed.

Improve detection diagnostics: only open the enumerated product id, report why a known wheel failed to open, and warn once about the legacy hid binding. Guard malformed telemetry packets and a missing hid module so neither takes down the session.

Fixes #43 