### PR TITLE
Reduce autodetect false positives

### DIFF
--- a/games/autodetect.py
+++ b/games/autodetect.py
@@ -1,4 +1,5 @@
 import os
+import re
 from pathlib import Path
 
 STEAM_APP_ID_KEYS = (
@@ -133,18 +134,23 @@ def detect_game_from_processes(processes):
             continue
         for signature in GAME_SIGNATURES:
             if app_id in signature["steam_app_ids"]:
+                # print (f"Detected that {signature["key"]} is running, from its Steam AppID")
                 return signature["key"]
 
     for process in processes:
-        name = process.get("name", "").lower()
-        cmdline = process.get("cmdline", "").lower()
+        name = process.get("name", "")
+        cmdline = process.get("cmdline", "")
         haystack = f"{name} {cmdline}"
         for signature in GAME_SIGNATURES:
             for token in signature["process_tokens"]:
-                if token in haystack:
+                if _findWholeWord(token)(haystack):
+                    # print (f"Detected that {signature["key"]} is running, from its Token (exe or name)")
                     return signature["key"]
     return None
 
+@staticmethod
+def _findWholeWord(w):
+    return re.compile(r'(?<!-)\b{}(?![-=])\b'.format(w), flags=re.IGNORECASE).search
 
 def detect_running_game():
     proc_dir = Path("/proc")

--- a/games/autodetect.py
+++ b/games/autodetect.py
@@ -148,9 +148,9 @@ def detect_game_from_processes(processes):
                     return signature["key"]
     return None
 
-@staticmethod
-def _findWholeWord(w):
-    return re.compile(r'(?<!-)\b{}(?![-=])\b'.format(w), flags=re.IGNORECASE).search
+def _findWholeWord(word):
+    escaped_word = re.escape(word)
+    return re.compile(r'(?<!-)\b{}(?![-=])\b'.format(escaped_word), flags=re.IGNORECASE).search
 
 def detect_running_game():
     proc_dir = Path("/proc")

--- a/tests/test_game_autodetect.py
+++ b/tests/test_game_autodetect.py
@@ -11,6 +11,33 @@ class TestGameAutoDetect(unittest.TestCase):
         ]
         self.assertEqual(detect_game_from_processes(processes), "assetto_corsa")
 
+    def test_should_not_detect_acc_when_name_in_other_process(self) -> None:
+        processes = [
+            {"name": "steam", "cmdline": "steam", "steam_app_id": ""},
+            {"name": "discord", "cmdline": "--enable-crash-reporter=9022b9dc-ac2--1-8f45-8f69e14bb8d5", "steam_app_id": "000000"},
+            {"name": "firefox-bin", "cmdline": "-initialChannelId {de789fbd--ac2-45bb-8b6d-36393222b64a}", "steam_app_id": "000000"},
+            {"name": "test_process1", "cmdline": "-ac2", "steam_app_id": "000000"},
+            {"name": "test_process2", "cmdline": "_ac2", "steam_app_id": "000000"},
+            {"name": "test_process1", "cmdline": "ac2-", "steam_app_id": "000000"},
+            {"name": "test_process2", "cmdline": "ac2_", "steam_app_id": "000000"},
+            {"name": "test_process3", "cmdline": "ac2=true", "steam_app_id": "000000"},
+        ]
+        self.assertIsNone(detect_game_from_processes(processes))
+
+    def test_should_detect_acc_when_token_assigned(self) -> None:
+        processes = [
+            {"name": "steam", "cmdline": "steam", "steam_app_id": ""},
+            {"name": "test_process", "cmdline": " --exe=ac2 ", "steam_app_id": "000000"},
+        ]
+        self.assertEqual(detect_game_from_processes(processes), "assetto_corsa_competizione")
+
+    def test_should_detect_acc_when_token_as_word(self) -> None:
+        processes = [
+            {"name": "steam", "cmdline": "steam", "steam_app_id": ""},
+            {"name": "start_process", "cmdline": "--exe ac2", "steam_app_id": "000000"},
+        ]
+        self.assertEqual(detect_game_from_processes(processes), "assetto_corsa_competizione")
+
     def test_detect_f1_23_by_process_token(self) -> None:
         processes = [
             {
@@ -20,6 +47,13 @@ class TestGameAutoDetect(unittest.TestCase):
             }
         ]
         self.assertEqual(detect_game_from_processes(processes), "f1_2023")
+
+    def test_detects_dirt_rally_2_by_name(self) -> None:
+        processes = [
+            {"name": "steam", "cmdline": "steam", "steam_app_id": ""},
+            {"name": "dirt rally 2.0", "cmdline": "", "steam_app_id": "000000"},
+        ]
+        self.assertEqual(detect_game_from_processes(processes), "dirt_rally_2_0")
 
     def test_detects_ets2_by_steam_app_id(self) -> None:
         processes = [

--- a/tests/test_game_autodetect.py
+++ b/tests/test_game_autodetect.py
@@ -55,6 +55,13 @@ class TestGameAutoDetect(unittest.TestCase):
         ]
         self.assertEqual(detect_game_from_processes(processes), "dirt_rally_2_0")
 
+    def test_does_not_detect_dirt_rally_2_by_name_when_point_replaced_by_X(self) -> None:
+        processes = [
+            {"name": "steam", "cmdline": "steam", "steam_app_id": ""},
+            {"name": "dirt rally 2X0", "cmdline": "", "steam_app_id": "000000"},
+        ]
+        self.assertIsNone(detect_game_from_processes(processes))
+
     def test_detects_ets2_by_steam_app_id(self) -> None:
         processes = [
             {"name": "steam", "cmdline": "steam", "steam_app_id": ""},


### PR DESCRIPTION
Only auto-detect games when their token is present as a word.
#49 is required, because tests added expect "assetto_corsa_competizione" to be present in autodetect.py.

- Short tokens can easily be present in UUID inside
  command line of other processes
- This only recognizes them if they are separated by "boundaries"
  (except - and _) like bland spaces or "=" prefix